### PR TITLE
feat: 도메인 구축

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,18 @@ plugins {
     id("io.spring.dependency-management") version "1.1.7"
 }
 
-group = "site"
-version = "0.0.1-SNAPSHOT"
+allprojects {
+    group = "site.yourevents"
+    version = "0.0.1-SNAPSHOT"
+
+    repositories {
+        mavenCentral()
+    }
+
+    tasks.withType<Test> {
+        useJUnitPlatform()
+    }
+}
 
 java {
     toolchain {
@@ -14,26 +24,24 @@ java {
     }
 }
 
-repositories {
-    mavenCentral()
-}
+subprojects {
+    apply(plugin = "org.jetbrains.kotlin.jvm")
+    apply(plugin = "org.jetbrains.kotlin.plugin.spring")
+    apply(plugin = "org.springframework.boot")
+    apply(plugin = "io.spring.dependency-management")
 
-dependencies {
-    implementation("org.springframework.boot:spring-boot-starter")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-    compileOnly("org.projectlombok:lombok")
-    annotationProcessor("org.projectlombok:lombok")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    dependencies {
+        implementation("org.springframework.boot:spring-boot-starter")
+        implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+        testImplementation("org.springframework.boot:spring-boot-starter-test")
+        testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    }
 }
 
 kotlin {
     compilerOptions {
         freeCompilerArgs.addAll("-Xjsr305=strict")
     }
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     kotlin("jvm") version "2.1.0"
-    kotlin("plugin.spring") version "2.1.0"
-    id("org.springframework.boot") version "3.4.1"
-    id("io.spring.dependency-management") version "1.1.7"
+    kotlin("plugin.spring") version "2.1.0" apply false
+    id("org.springframework.boot") version "3.4.1" apply false
+    id("io.spring.dependency-management") version "1.1.7" apply false
 }
 
 allprojects {

--- a/module-domain/build.gradle.kts
+++ b/module-domain/build.gradle.kts
@@ -1,0 +1,7 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true

--- a/module-domain/src/main/kotlin/site/yourevents/invitation/Guest.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/invitation/Guest.kt
@@ -1,0 +1,13 @@
+package site.yourevents.invitation
+
+import site.yourevents.member.Member
+import java.util.UUID
+
+class Guest(
+    private val id: UUID,
+    private val member: Member,
+    private val invitation: Invitation,
+    private val nickname: String,
+    private val attendance: Boolean,
+) {
+}

--- a/module-domain/src/main/kotlin/site/yourevents/invitation/Invitation.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/invitation/Invitation.kt
@@ -1,0 +1,11 @@
+package site.yourevents.invitation
+
+import site.yourevents.member.Member
+import java.util.UUID
+
+class Invitation(
+    private val id: UUID,
+    private val member: Member,
+    private val qrUrl: String,
+) {
+}

--- a/module-domain/src/main/kotlin/site/yourevents/invitation/InvitationInformation.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/invitation/InvitationInformation.kt
@@ -1,0 +1,14 @@
+package site.yourevents.invitation
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+class InvitationInformation(
+    private val id: UUID,
+    private val invitation: Invitation,
+    private var title: String,
+    private var schedule: LocalDateTime,
+    private var location: String,
+    private var remark: String,
+) {
+}

--- a/module-domain/src/main/kotlin/site/yourevents/invitation/InvitationThumbnail.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/invitation/InvitationThumbnail.kt
@@ -1,0 +1,10 @@
+package site.yourevents.invitation
+
+import java.util.UUID
+
+class InvitationThumbnail(
+    private val id: UUID,
+    private val invitation: Invitation,
+    private val url: String,
+) {
+}

--- a/module-domain/src/main/kotlin/site/yourevents/member/Member.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/member/Member.kt
@@ -1,0 +1,11 @@
+package site.yourevents.member
+
+import java.util.UUID
+
+class Member(
+    private val id: UUID,
+    private val nickname: String,
+    private val socialId: String,
+    private val email: String,
+) {
+}

--- a/module-infrastructure/persistence-db/build.gradle.kts
+++ b/module-infrastructure/persistence-db/build.gradle.kts
@@ -1,0 +1,26 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true
+
+plugins {
+    kotlin("plugin.jpa") version "2.1.0"
+}
+
+allOpen {
+    annotation("jakarta.persistence.Entity")
+    annotation("jakarta.persistence.MappedSuperclass")
+    annotation("javax.persistence.Embeddable")
+}
+
+dependencies {
+    implementation(project(":module-domain"))
+
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // MySQL
+    runtimeOnly("com.mysql:mysql-connector-j")
+}

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/GuestEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/GuestEntity.kt
@@ -1,0 +1,33 @@
+package site.yourevents.invitation
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import site.yourevents.member.entity.MemberEntity
+import java.util.UUID
+
+@Entity(name = "guest")
+class GuestEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID,
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: MemberEntity,
+
+    @ManyToOne
+    @JoinColumn(name = "invitation_id", nullable = false)
+    val invitation: InvitationEntity,
+
+    @Column
+    val nickname: String,
+
+    @Column(nullable = false)
+    val attendance: Boolean,
+) {
+}

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/InvitationEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/InvitationEntity.kt
@@ -1,0 +1,26 @@
+package site.yourevents.invitation
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import site.yourevents.member.entity.MemberEntity
+import java.util.UUID
+
+@Entity(name = "invitation")
+class InvitationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID,
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    val member: MemberEntity,
+
+    @Column
+    val qrUrl: String,
+) {
+}

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/InvitationInformationEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/InvitationInformationEntity.kt
@@ -1,0 +1,35 @@
+package site.yourevents.invitation
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Entity(name = "invitation_information")
+class InvitationInformationEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID,
+
+    @ManyToOne
+    @JoinColumn(name = "invitation_id", nullable = false)
+    val invitation: InvitationEntity,
+
+    @Column
+    var title: String,
+
+    @Column
+    var schedule: LocalDateTime,
+
+    @Column
+    var location: String,
+
+    @Column
+    var remark: String,
+) {
+}

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/InvitationThumbnailEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/invitation/InvitationThumbnailEntity.kt
@@ -1,0 +1,25 @@
+package site.yourevents.invitation
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import java.util.UUID
+
+@Entity(name = "invitation_thumbnail")
+class InvitationThumbnailEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    val id: UUID,
+
+    @ManyToOne
+    @JoinColumn(name = "invitation_id", nullable = false)
+    val invitation: InvitationEntity,
+
+    @Column(nullable = false)
+    val url: String,
+) {
+}

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/member/entity/MemberEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/member/entity/MemberEntity.kt
@@ -1,0 +1,25 @@
+package site.yourevents.member.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import java.util.UUID
+
+@Entity(name = "member")
+class MemberEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private val id: UUID,
+
+    @Column
+    private val nickname: String,
+
+    @Column
+    private val socialId: String,
+
+    @Column
+    private val email: String,
+) {
+}

--- a/module-presentation/build.gradle.kts
+++ b/module-presentation/build.gradle.kts
@@ -1,0 +1,16 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = true
+jar.enabled = false
+
+dependencies {
+    implementation(project(":module-domain"))
+    implementation(project(":module-infrastructure:persistence-db"))
+
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
+}

--- a/module-presentation/src/main/kotlin/site/yourevents/YourEventsApplication.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/YourEventsApplication.kt
@@ -1,0 +1,11 @@
+package site.yourevents
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class YourEventsApplication
+
+fun main(args: Array<String>) {
+    runApplication<YourEventsApplication>(*args)
+}

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -1,0 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: local
+  datasource:
+    url: jdbc:mysql://localhost:3306/yourevents
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,8 @@
 rootProject.name = "yourevents"
+
+include("module-presentation")
+
+include("module-domain")
+
+include("module-infrastructure")
+include("module-infrastructure:persistence-db")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 모듈 구축
```
모듈 구조
├── module-presentation  // API 게이트웨이 모듈
├── module-domain  // 도메인 모듈
├── module-infrastructure  // 외부 모듈
    └── persistence-db // DB(JPA) 모듈
```
- 멀티 모듈을 통한 헥사고날 아키텍처를 적용하기 위해 모듈을 분리하였습니다.
  - 도메인 모듈은 순소 코틀린으로만 구성되어 있습니다.
  - 외부 모듈에 속해 있는 지속성-db 모듈에서 JPA 의존성을 통해 MySQL이랑 도메인 객체가 엔티티로 매핑되어 연결됩니다.
- 프레젠테이션 모듈은 게이트웨이의 책임을 지니고 있으며, 해당 모듈 내의 `YourEventsApplication.kt` 파일을 실행하여 서비스를 시작할 수 있습니다.

### 엔티티 생성
#### 스크린샷 
<img width="244" alt="스크린샷 2024-12-28 오전 12 47 00" src="https://github.com/user-attachments/assets/b2a3447a-a55f-4851-9272-367bfabf8cde" />


---

## 🔗 관련 이슈
- closes #1 

---

## 💡 추가 사항
### 참고 자료
- [멀티 모듈 구축 예시 블로그](https://k-in.tistory.com/211)
- [디프만 헥사고날 아키텍쳐 적용 서비스: Swimie](https://github.com/depromeet/Swimie-server)
