### PR TITLE
feat: 공통 응답 객체 구현

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI with Test Results
+
+on:
+  pull_request:
+    branches-ignore: [ "main" ]
+
+jobs:
+  dev-build-TEST:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: GitHub Checkout
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설정
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Gradle Wrapper 권한 부여
+        run: chmod +x gradlew
+
+      - name: Gradle 테스트
+        run: ./gradlew --info test
+
+      - name: Test 결과 출력
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          junit_files: '**/build/test-results/test/TEST-*.xml'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,9 +34,16 @@ subprojects {
         implementation("org.springframework.boot:spring-boot-starter")
         implementation("org.jetbrains.kotlin:kotlin-reflect")
 
+        // test
         testImplementation("org.springframework.boot:spring-boot-starter-test")
-        testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+        // kotest
+        testImplementation("io.kotest:kotest-runner-junit5:5.9.0")
+        testImplementation("io.kotest:kotest-assertions-core:5.9.0")
+        testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
+
+        // mockk
+        testImplementation("io.mockk:mockk:1.13.13")
     }
 }
 

--- a/module-independent/build.gradle.kts
+++ b/module-independent/build.gradle.kts
@@ -1,0 +1,7 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true

--- a/module-independent/src/main/kotlin/site/yourevents/error/ErrorCode.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/error/ErrorCode.kt
@@ -1,0 +1,18 @@
+package site.yourevents.error
+
+enum class ErrorCode(
+    val httpStatus: Int,
+    val code: String,
+    val message: String,
+) {
+    INVALID_TOKEN(401, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(401, "EXPIRED_TOKEN", "만료된 토큰입니다."),
+    MALFORMED_TOKEN(401, "MALFORMED_TOKEN", "위/변조된 토큰입니다."),
+    UNSUPPORTED_TOKEN(401, "UNSUPPORTED_TOKEN", "지원하지 않는 토큰입니다."),
+    EMPTY_AUTHENTICATION(401, "EMPTY_AUTHENTICATION", "인증정보가 존재하지 않습니다."),
+    ROLE_FORBIDDEN(403, "ROLE_FORBIDDEN", "접근할 수 있는 권한이 아닙니다."),
+    PASSWORD_NOT_MATCH(403, "PASSWORD_NOT_MATCH", "비밀번호가 일치하지 않습니다."),
+    USER_NOT_FOUND(404, "USER_NOT_FOUND", "존재하지 않는 사용자입니다."),
+    ADMIN_NOT_FOUND(404, "ADMIN_NOT_FOUND", "존재하지 않는 관리자입니다."),
+    INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."),
+}

--- a/module-independent/src/main/kotlin/site/yourevents/error/exception/ServiceException.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/error/exception/ServiceException.kt
@@ -1,6 +1,6 @@
 package site.yourevents.error.exception
 
-import site.yourevents.error.ErrorCode
+import site.yourevents.type.ErrorCode
 
 class ServiceException(
     private val errorCode: ErrorCode

--- a/module-independent/src/main/kotlin/site/yourevents/error/exception/ServiceException.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/error/exception/ServiceException.kt
@@ -1,0 +1,8 @@
+package site.yourevents.error.exception
+
+import site.yourevents.error.ErrorCode
+
+class ServiceException(
+    private val errorCode: ErrorCode
+) : RuntimeException() {
+}

--- a/module-independent/src/main/kotlin/site/yourevents/response/ApiResponse.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/response/ApiResponse.kt
@@ -1,6 +1,7 @@
 package site.yourevents.response
 
-import site.yourevents.error.ErrorCode
+import site.yourevents.type.ErrorCode
+import site.yourevents.type.SuccessCode
 
 data class ApiResponse<T>(
     val status: Int,

--- a/module-independent/src/main/kotlin/site/yourevents/response/ApiResponse.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/response/ApiResponse.kt
@@ -7,9 +7,29 @@ data class ApiResponse<T>(
     val status: Int,
     val code: String,
     val message: String,
+    val result: T? = null,
 ) {
     companion object {
+        fun success(success: SuccessCode): ApiResponse<Unit> =
+            ApiResponse(
+                status = success.httpStatus,
+                code = success.code,
+                message = success.message,
+            )
+
+        fun <T> success(success: SuccessCode, result: T): ApiResponse<T> =
+            ApiResponse(
+                status = success.httpStatus,
+                code = success.code,
+                message = success.message,
+                result = result
+            )
+
         fun error(e: ErrorCode): ApiResponse<Unit> =
-            ApiResponse(status = e.httpStatus, code = e.code, message = e.message)
+            ApiResponse(
+                status = e.httpStatus,
+                code = e.code,
+                message = e.message,
+            )
     }
 }

--- a/module-independent/src/main/kotlin/site/yourevents/response/ApiResponse.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/response/ApiResponse.kt
@@ -1,0 +1,14 @@
+package site.yourevents.response
+
+import site.yourevents.error.ErrorCode
+
+data class ApiResponse<T>(
+    val status: Int,
+    val code: String,
+    val message: String,
+) {
+    companion object {
+        fun error(e: ErrorCode): ApiResponse<Unit> =
+            ApiResponse(status = e.httpStatus, code = e.code, message = e.message)
+    }
+}

--- a/module-independent/src/main/kotlin/site/yourevents/type/ErrorCode.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/type/ErrorCode.kt
@@ -1,4 +1,4 @@
-package site.yourevents.error
+package site.yourevents.type
 
 enum class ErrorCode(
     val httpStatus: Int,

--- a/module-independent/src/main/kotlin/site/yourevents/type/SuccessCode.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/type/SuccessCode.kt
@@ -1,0 +1,8 @@
+package site.yourevents.type
+
+enum class SuccessCode(
+    val httpStatus: Int,
+    val code: String,
+    val message: String,
+) {
+}

--- a/module-independent/src/main/kotlin/site/yourevents/type/SuccessCode.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/type/SuccessCode.kt
@@ -5,4 +5,5 @@ enum class SuccessCode(
     val code: String,
     val message: String,
 ) {
+    REQUEST_OK(200, "OK", "요청이 성공적으로 처리되었습니다."),
 }

--- a/module-independent/src/test/kotlin/site/yourevents/response/ApiResponseTest.kt
+++ b/module-independent/src/test/kotlin/site/yourevents/response/ApiResponseTest.kt
@@ -1,0 +1,45 @@
+package site.yourevents.response
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import site.yourevents.type.ErrorCode
+import site.yourevents.type.SuccessCode
+
+class ApiResponseTest : DescribeSpec({
+    describe("ApiResponse") {
+        context("성공 응답을 반환할 때") {
+            it("응답 값이 없으면 status, code, message가 올바르게 반환되고, result는 null이어야 한다.") {
+                val successCode = SuccessCode.REQUEST_OK
+                val response = ApiResponse.success(successCode)
+
+                response.status shouldBe successCode.httpStatus
+                response.code shouldBe successCode.code
+                response.message shouldBe successCode.message
+                response.result shouldBe null
+            }
+
+            it("응답 값이 있으면 status, code, message, result가 올바르게 반환되어야 한다.") {
+                val successCode = SuccessCode.REQUEST_OK
+                val result = "응답 값"
+                val response = ApiResponse.success(successCode, result)
+
+                response.status shouldBe successCode.httpStatus
+                response.code shouldBe successCode.code
+                response.message shouldBe successCode.message
+                response.result shouldBe result
+            }
+        }
+
+        context("오류 응답을 반환할 때") {
+            it("status, code, message가 올바르게 반환되고 result는 null이어야 한다.") {
+                val errorCode = ErrorCode.INTERNAL_SERVER_ERROR
+                val response = ApiResponse.error(errorCode)
+
+                response.status shouldBe errorCode.httpStatus
+                response.code shouldBe errorCode.code
+                response.message shouldBe errorCode.message
+                response.result shouldBe null
+            }
+        }
+    }
+})

--- a/module-infrastructure/security/build.gradle.kts
+++ b/module-infrastructure/security/build.gradle.kts
@@ -1,0 +1,24 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true
+
+dependencies {
+    //Spring Security
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+
+    //OAuth 2.0
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+
+    //JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+    // Spring Security Test
+    testImplementation("org.springframework.security:spring-security-test")
+}

--- a/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
+++ b/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
@@ -7,6 +7,8 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.invoke
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource
 
 
 @Configuration
@@ -25,8 +27,23 @@ class SecurityConfig(
             sessionManagement { SessionCreationPolicy.STATELESS }
             // TODO: OAuth 설정
             // TODO: JJWT 설정
-            // TODO: CORS 설정
         }
         return http.build()
+    }
+
+    @Bean
+    fun corsConfigurationSource(): UrlBasedCorsConfigurationSource {
+        val configuration = CorsConfiguration()
+        configuration.allowedOrigins = listOf(
+            "http://localhost:3000",
+            "https://www.yourevents.site",
+            "https://yourevents.site",
+            "http://localhost:8080")
+        configuration.allowedMethods = listOf("POST", "GET", "PATCH", "DELETE", "OPTIONS")
+        configuration.allowedHeaders = listOf("*")
+
+        val source = UrlBasedCorsConfigurationSource()
+        source.registerCorsConfiguration("/**", configuration)
+        return source
     }
 }

--- a/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
+++ b/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
@@ -1,0 +1,32 @@
+package site.yourevents
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig(
+) {
+    @Bean
+    fun SecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            authorizeHttpRequests {
+                authorize(anyRequest, permitAll)
+            }
+            csrf { disable() }
+            formLogin { disable() }
+            httpBasic { disable() }
+            sessionManagement { SessionCreationPolicy.STATELESS }
+            // TODO: OAuth 설정
+            // TODO: JJWT 설정
+            // TODO: CORS 설정
+        }
+        return http.build()
+    }
+}

--- a/module-presentation/src/main/resources/application.yml
+++ b/module-presentation/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/yourevents
+    username: root
+    password:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        use_sql_comments: true

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,3 +8,4 @@ include("module-infrastructure")
 include("module-infrastructure:persistence-db")
 
 include("module-independent")
+include("module-infrastructure:security")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,3 +6,5 @@ include("module-domain")
 
 include("module-infrastructure")
 include("module-infrastructure:persistence-db")
+
+include("module-independent")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용
### 예외-성공 타입
- 모든 예외(실패), 성공 응답 여부는 총 3개의 프로퍼티를 지니고 있습니다:
  - **httpStatus**(e.g. 401)
  - **code**(e.g. INVALID_TOKEN..etc)
  - **message**(e.g. 유효하지 않은 토큰입니다.)
 
- 해당 타입을 통해 공통 응답을 반환합니다.

### 커스텀 예외
- `RuntimeException`을 상속받아 커스텀 예외를 처리할 수 있도록 하였습니다.
  - 커스텀 예외 클래스는 직접 정의하는 **ErrorCode**를 포함하고 있습니다.

### 공통 응답 객체 **ApiResponse**
- 다음과 같은 총 4개의 프로퍼티를 포함합니다:
  - status (Int): HTTP 상태 코드를 나타냅니다.
  - code (String): 응답 상태를 식별하는 커스텀 코드입니다.
  - message (String): 응답에 대한 상세 메시지입니다.
  - result (T?): 요청에 대한 응답 값입니다. 성공 응답인 경우에 포함되며, 실패 응답이거나 불필요한  경우 null일 수 있습니다.

### Companion Object
> [!NOTE]
> 자바에서의 정적 팩토리 메서드를 통해 객체 생성 과정에서의 가독성을 늘렸다면, 
코틀린에서는 이를 **Companion Object**를 통해 구현해줄 수 있습니다.

<img width="666" alt="image" src="https://github.com/user-attachments/assets/cb9a8010-0c0a-439f-9ba4-f4d9070d1e83" />


```kotlin
ApiResponse.success(SuccessCode.SUCCESS) // 단순 성공 응답의 경우
ApiResponse.success(SuccessCode.SUCCESS, data) // 응답 값을 포함하는 성공 응답의 경우
ApiResponse.error(ErrorCode.INVALID_TOKEN) // 커스텀 예외 처리 시
```

---

## 🔗 관련 이슈
- closes #3

---

## 💡 추가 사항
- 테스트 코드를 위한 Mockk, KoTest 의존성을 추가하였습니다!
- PR시 테스트 확인 자동화를 위한 GitHub Actions CI 워크플로 파일을 추가하였습니다!
