### PR TITLE
chore: Sentry 구축 및 Docker 이미지 빌드 오류 수정

### DIFF
--- a/module-infrastructure/monitoring/build.gradle.kts
+++ b/module-infrastructure/monitoring/build.gradle.kts
@@ -6,10 +6,6 @@ val bootJar: BootJar by tasks
 bootJar.enabled = false
 jar.enabled = true
 
-plugins {
-    kotlin("plugin.jpa") version "2.1.0"
-}
-
 dependencies {
 
     // Sentry

--- a/module-infrastructure/monitoring/build.gradle.kts
+++ b/module-infrastructure/monitoring/build.gradle.kts
@@ -13,6 +13,6 @@ plugins {
 dependencies {
 
     // Sentry
-    api("io.sentry:sentry-logback:7.17.0")
-    api("com.github.maricn:logback-slack-appender:1.6.1")
+    implementation("io.sentry:sentry-logback:7.17.0")
+    implementation("com.github.maricn:logback-slack-appender:1.6.1")
 }

--- a/module-infrastructure/monitoring/build.gradle.kts
+++ b/module-infrastructure/monitoring/build.gradle.kts
@@ -1,0 +1,18 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+val jar: Jar by tasks
+val bootJar: BootJar by tasks
+
+bootJar.enabled = false
+jar.enabled = true
+
+plugins {
+    kotlin("plugin.jpa") version "2.1.0"
+}
+
+dependencies {
+
+    // Sentry
+    api("io.sentry:sentry-logback:7.17.0")
+    api("com.github.maricn:logback-slack-appender:1.6.1")
+}

--- a/module-infrastructure/monitoring/src/main/kotlin/site/yourevents/sentry/SentryConfig.kt
+++ b/module-infrastructure/monitoring/src/main/kotlin/site/yourevents/sentry/SentryConfig.kt
@@ -1,0 +1,22 @@
+package site.yourevents.sentry
+
+import io.sentry.Sentry
+import jakarta.annotation.PostConstruct
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SentryConfig(
+    @Value("\${sentry.dsn}") private val sentryDsn: String,
+    @Value("\${sentry.environment}") private val environment: String,
+    @Value("\${sentry.servername}") private val serverName: String
+) {
+    @PostConstruct
+    fun initSentry() {
+        Sentry.init { options ->
+            options.dsn = sentryDsn
+            options.environment = environment
+            options.serverName = serverName
+        }
+    }
+}

--- a/module-infrastructure/monitoring/src/main/kotlin/site/yourevents/sentry/SentryConfig.kt
+++ b/module-infrastructure/monitoring/src/main/kotlin/site/yourevents/sentry/SentryConfig.kt
@@ -7,9 +7,14 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class SentryConfig(
-    @Value("\${sentry.dsn}") private val sentryDsn: String,
-    @Value("\${sentry.environment}") private val environment: String,
-    @Value("\${sentry.servername}") private val serverName: String
+    @Value("\${sentry.dsn}")
+    private val sentryDsn: String,
+
+    @Value("\${sentry.environment}")
+    private val environment: String,
+
+    @Value("\${sentry.servername}")
+    private val serverName: String
 ) {
     @PostConstruct
     fun initSentry() {

--- a/module-infrastructure/monitoring/src/main/resources/console-appender.xml
+++ b/module-infrastructure/monitoring/src/main/resources/console-appender.xml
@@ -1,0 +1,8 @@
+<included>
+    <appender name="CONSOLE"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/module-infrastructure/monitoring/src/main/resources/logback-spring.xml
+++ b/module-infrastructure/monitoring/src/main/resources/logback-spring.xml
@@ -36,8 +36,8 @@
         <include resource="console-appender.xml"/>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
-            <appender-ref ref="Sentry"/>
-            <appender-ref ref="ASYNC_SLACK"/>
+<!--            <appender-ref ref="Sentry"/>-->
+<!--            <appender-ref ref="ASYNC_SLACK"/>-->
         </root>
     </springProfile>
 

--- a/module-infrastructure/monitoring/src/main/resources/logback-spring.xml
+++ b/module-infrastructure/monitoring/src/main/resources/logback-spring.xml
@@ -1,0 +1,53 @@
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <property name="LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] %green([%thread]) %highlight(%-5level) %boldWhite([%C.%M:%yellow(%L)]) - %msg%n"/>
+
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <maxRequestBodySize>always</maxRequestBodySize>
+        <sendDefaultPii>true</sendDefaultPii>
+        <tracesSampleRate>1.0</tracesSampleRate>
+        <minimumEventLevel>ERROR</minimumEventLevel>
+        <minimumBreadcrumbLevel>DEBUG</minimumBreadcrumbLevel>
+    </appender>
+
+    <springProperty name="SENTRY_REPOSITORY_URI" source="logging.sentry.repository-uri"/>
+    <springProperty name="ENVIRONMENT" source="logging.sentry.environment"/>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-url"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>*🚨[${ENVIRONMENT}] %d{yyyy-MM-dd HH:mm:ss.SSS} %-4relative [%thread] %-5level %class - %msg &lt;${SENTRY_REPOSITORY_URI}|Go-To-Sentry&gt;*
+                %n
+            </pattern>
+        </layout>
+        <username>Error-Bot</username>
+        <iconEmoji>:robot_face:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="Sentry"/>
+            <appender-ref ref="ASYNC_SLACK"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="dev">
+        <include resource="console-appender.xml"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="Sentry"/>
+            <appender-ref ref="ASYNC_SLACK"/>
+        </root>
+    </springProfile>
+
+</configuration>

--- a/module-presentation/build.gradle.kts
+++ b/module-presentation/build.gradle.kts
@@ -9,6 +9,7 @@ jar.enabled = false
 
 dependencies {
     implementation(project(":module-domain"))
+    implementation(project(":module-infrastructure:monitoring"))
     implementation(project(":module-infrastructure:persistence-db"))
     implementation(project(":module-independent"))
 

--- a/module-presentation/build.gradle.kts
+++ b/module-presentation/build.gradle.kts
@@ -2,6 +2,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 val jar: Jar by tasks
 val bootJar: BootJar by tasks
+val jarName = "app.jar"
 
 bootJar.enabled = true
 jar.enabled = false
@@ -24,4 +25,15 @@ dependencies {
 
 tasks.getByName<BootJar>("bootJar") {
     mainClass.set("site.yourevents.YourEventsApplicationKt")
+}
+
+tasks.named<BootJar>("bootJar") {
+    archiveFileName.set(jarName)
+
+    doLast {
+        copy {
+            from("build/libs/$jarName")
+            into("../build/libs")
+        }
+    }
 }

--- a/module-presentation/src/main/resources/application-dev.yml
+++ b/module-presentation/src/main/resources/application-dev.yml
@@ -17,3 +17,16 @@ spring:
 app:
   server:
     url: ENC(uN3Diby1cLKgQIKPznbuLr/9mQrqzUFhTlzKRp4ZCSxovF26NNCo+A==)
+
+sentry:
+  dsn: ENC(UefOk3EHvOlzQ+99rApWCWoEMEbTlVbECMRxnRLgtNzuWJa0PmWL1pBtfGRpRK6qWsOSGlmWlJsP7PI7JVaLOnHG3CDLM2bChy61gXTkqYiTs2I1Axf8SW/rxMmcEkH7PLOqEY/TI5I=
+  environment: ENC(5Nbdf/7y1sF9NAU0jw0SCg==)
+  servername: ENC(Tf/+6HqlCb8m17xkhfHjhw==)
+
+logging:
+  config: classpath:logback-spring.xml
+  sentry:
+    repository-uri: ENC(g0Krw6t6uRDttMcJbvX50G2tfUmi+5R+jH6C40Q6Je2kLfCArJNWdSG/YBoIq0+E1zsJamVrVfqG3tOgLWqPMppT9zVlHC60z4Mw9VrXPBFzaZrkXDb+UnAL+WggMg2SzzN0iapM7xo=)
+    environment: ENC(GWw5mEHTRfd0Ngg/p8uZ7Q==)
+  slack:
+    webhook-url: ENC(2V14VMxtr6ga6VYnVumgqqYDdzRfcUzO0+QXJl26W0bfHoVW7APdzecmMuA6/KWENMB3M1SFw5bqwOsI0hdYtzOX6aKicOBAadZ1ESN8fcPsB7b5GaTI1TI/wUdMjTEc)

--- a/module-presentation/src/main/resources/application-dev.yml
+++ b/module-presentation/src/main/resources/application-dev.yml
@@ -26,7 +26,7 @@ sentry:
 logging:
   config: classpath:logback-spring.xml
   sentry:
-    repository-uri: ENC(g0Krw6t6uRDttMcJbvX50G2tfUmi+5R+jH6C40Q6Je2kLfCArJNWdSG/YBoIq0+E1zsJamVrVfqG3tOgLWqPMppT9zVlHC60z4Mw9VrXPBFzaZrkXDb+UnAL+WggMg2SzzN0iapM7xo=)
-    environment: ENC(GWw5mEHTRfd0Ngg/p8uZ7Q==)
+    repository-uri: ${SENTRY_REPOSITORY_URI}
+    environment:  ${SENTRY_ENVIRONMENT}
   slack:
-    webhook-url: ENC(2V14VMxtr6ga6VYnVumgqqYDdzRfcUzO0+QXJl26W0bfHoVW7APdzecmMuA6/KWENMB3M1SFw5bqwOsI0hdYtzOX6aKicOBAadZ1ESN8fcPsB7b5GaTI1TI/wUdMjTEc)
+    webhook-url: ${SLACK_WEBHOOK_URL}

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -17,3 +17,16 @@ spring:
 app:
   server:
     url: http://localhost:8080
+
+sentry:
+  dsn: ENC(p3USktYJhoxYtz0GFLCVpu4fki0u0eN424zqg6rE3vKH5DjjWfqFRN+Enj/rLkCFAhYwlwFtT++KW62gqtm1CnnHxeJfrAki+FdAnWO3JRj29aXea/N8xrE7h/MoZ58Tapyi+wWH5eM=)
+  environment: ENC(FVBHvqTsvv2ytyUnt6i2lw==)
+  servername: ENC(cGNqcZ4YnA0ufysvNrAyVzDz1/w6/vUi)
+
+logging:
+  config: classpath:logback-spring.xml
+  sentry:
+    repository-uri: ENC(Ql7eE0mWdzUcjepLC2Eq7e2PyXyNaG0V2onethHlafhcJ5t9pLBZmeroj3+vkM9zp88YIwxcvMks69YZrEeXBT0MX7C028pAJsxCM54G+wF/uXclw0xOXM9DgWaEkBheAuav6C5Mwqg=)
+    environment: ENC(qaAYY+h/ALoN3KDILvoV+g==)
+  slack:
+    webhook-url: ENC(WHEGoh730wj5KIl+MTr2LTifDVemTwX9+LimiJRRsEnynVGHb7ev0jqY55Su8FfeX6IAh17LRa6NeM42h/tJFR1trqv0iflQZFDKi0/l+VSGBhTBg39s4K0O1bjmeEHN)

--- a/module-presentation/src/main/resources/application-local.yml
+++ b/module-presentation/src/main/resources/application-local.yml
@@ -26,7 +26,7 @@ sentry:
 logging:
   config: classpath:logback-spring.xml
   sentry:
-    repository-uri: ENC(Ql7eE0mWdzUcjepLC2Eq7e2PyXyNaG0V2onethHlafhcJ5t9pLBZmeroj3+vkM9zp88YIwxcvMks69YZrEeXBT0MX7C028pAJsxCM54G+wF/uXclw0xOXM9DgWaEkBheAuav6C5Mwqg=)
-    environment: ENC(qaAYY+h/ALoN3KDILvoV+g==)
+    repository-uri: ${SENTRY_REPOSITORY_URI}
+    environment:  ${SENTRY_ENVIRONMENT}
   slack:
-    webhook-url: ENC(WHEGoh730wj5KIl+MTr2LTifDVemTwX9+LimiJRRsEnynVGHb7ev0jqY55Su8FfeX6IAh17LRa6NeM42h/tJFR1trqv0iflQZFDKi0/l+VSGBhTBg39s4K0O1bjmeEHN)
+    webhook-url: ${SLACK_WEBHOOK_URL}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,8 @@ include("module-presentation")
 include("module-domain")
 
 include("module-infrastructure")
+include("module-infrastructure:security")
+include("module-infrastructure:monitoring")
 include("module-infrastructure:persistence-db")
 
 include("module-independent")
-include("module-infrastructure:security")


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용

- [x] `Dockerfile`에서 명시한 `app.jar`의 위치에 `app.jar` 파일이 생성되지 않아, Dokcer 이미지가 빌드되지 못한 오류를 해결하였습니다.
- [x] Sentry 및 Slack Webhook을 구축하였습니다. 

- 팀 Slack으로 Server에서 오류가 발생하면, 알림이 오는 화면
<img width="979" alt="image" src="https://github.com/user-attachments/assets/c79e646f-8ad9-4e20-832c-e4caf069c96c" />

---

## 🔗 관련 이슈
- closes #8 

---

## 💡 추가 사항
- Sentry 계정은 팀 노션에 추가하겠습니다.
-  현재 local 환경에서도 알림이 오도록 구현이 되어있는데, local 환경에서의 오류에 대한 알림에 대한 의견 부탁드립니다.
  (저는 개인적으로 끄는 것이 좋다고 생각합니다!)
- Slack WebHook에 대한 방법은 해당 [링크](https://velog.io/@king/slack-incoming-webhook)를 확인하면 됩니다!
- WebHook 설정 파일은 Jasypt 암호화가 적용될 수 없어, 해당 부분에 대한 환경 변수를 팀 노션에 첨부했습니다.