### PR TITLE
feat: 초대장 수락/거절 기능 구현

### DIFF
--- a/module-domain/src/main/kotlin/site/yourevents/guest/domain/Guest.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/domain/Guest.kt
@@ -9,6 +9,9 @@ class Guest(
     val member: Member,
     val invitation: Invitation,
     val nickname: String,
-    val attendance: Boolean,
+    var attendance: Boolean,
 ) {
+    fun updateAttendance(attendance: Boolean) {
+        this.attendance = attendance
+    }
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/domain/GuestVO.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/domain/GuestVO.kt
@@ -2,20 +2,10 @@ package site.yourevents.guest.domain
 
 import site.yourevents.invitation.domain.Invitation
 import site.yourevents.member.domain.Member
-import java.util.UUID
 
 data class GuestVO(
     val member: Member,
     val invitation: Invitation,
     val nickname: String,
     val attendance: Boolean
-) {
-    companion object {
-        fun from(guestVO: GuestVO): GuestVO = GuestVO(
-            member = guestVO.member,
-            invitation = guestVO.invitation,
-            nickname = guestVO.nickname,
-            attendance = guestVO.attendance
-        )
-    }
-}
+)

--- a/module-domain/src/main/kotlin/site/yourevents/guest/exception/GuestNotFoundException.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/exception/GuestNotFoundException.kt
@@ -1,0 +1,6 @@
+package site.yourevents.guest.exception
+
+import site.yourevents.error.exception.ServiceException
+import site.yourevents.type.ErrorCode
+
+class GuestNotFoundException : ServiceException(ErrorCode.GUEST_NOT_FOUND)

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -9,4 +9,12 @@ interface GuestUseCase {
         invitationId: UUID,
         nickname: String
     ): Guest
+
+    fun respondInvitation(
+        guestId: UUID?,
+        invitationId: UUID,
+        memberId: UUID,
+        nickname: String,
+        attendance: Boolean,
+    )
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -2,7 +2,12 @@ package site.yourevents.guest.port.out
 
 import site.yourevents.guest.domain.Guest
 import site.yourevents.guest.domain.GuestVO
+import java.util.UUID
 
 interface GuestPersistencePort {
     fun save(guestVo: GuestVO): Guest
+
+    fun save(guest: Guest)
+
+    fun findById(guestId: UUID): Guest?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -22,21 +22,21 @@ class GuestService(
     override fun createGuest(
         memberId: UUID,
         invitationId: UUID,
-        nickname: String): Guest {
-
+        nickname: String
+    ): Guest {
         val member = memberUseCase.findById(memberId)
             ?: throw MemberNotFountException()
 
         val invitation = invitationUseCase.findById(invitationId)
             ?: throw InvitationNotFoundException()
 
-
         return guestPersistencePort.save(
-            GuestVO.from(GuestVO(
+            GuestVO(
                 member = member,
                 invitation = invitation,
                 nickname = nickname,
-                attendance = true))
+                attendance = true
+            )
         )
     }
 

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -39,4 +39,14 @@ class GuestService(
                 attendance = true))
         )
     }
+
+    override fun respondInvitation(
+        guestId: UUID?,
+        invitationId: UUID,
+        memberId: UUID,
+        nickname: String,
+        attendance: Boolean
+    ) {
+        TODO("Not yet implemented")
+    }
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import site.yourevents.guest.domain.Guest
 import site.yourevents.guest.domain.GuestVO
+import site.yourevents.guest.exception.GuestNotFoundException
 import site.yourevents.guest.port.`in`.GuestUseCase
 import site.yourevents.guest.port.out.GuestPersistencePort
 import site.yourevents.invitation.exception.InvitationNotFoundException
@@ -47,6 +48,31 @@ class GuestService(
         nickname: String,
         attendance: Boolean
     ) {
-        TODO("Not yet implemented")
+        val member = memberUseCase.findById(memberId)
+            ?: throw MemberNotFountException()
+
+        val invitation = invitationUseCase.findById(invitationId)
+            ?: throw InvitationNotFoundException()
+
+        if (guestId == null) {
+            guestPersistencePort.save(
+                GuestVO(
+                    member = member,
+                    invitation = invitation,
+                    nickname = nickname,
+                    attendance = attendance
+                )
+            )
+            return
+        }
+        updateAttendance(guestId, attendance)
+    }
+
+    private fun updateAttendance(guestId: UUID, attendance: Boolean) {
+        val guest = guestPersistencePort.findById(guestId)
+            ?: throw GuestNotFoundException()
+
+        guest.updateAttendance(attendance)
+        guestPersistencePort.save(guest)
     }
 }

--- a/module-domain/src/test/kotlin/site/yourevents/guest/domain/GuestVOTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/domain/GuestVOTest.kt
@@ -4,7 +4,7 @@ import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import site.yourevents.invitation.domain.Invitation
 import site.yourevents.member.domain.Member
-import java.util.*
+import java.util.UUID
 
 class GuestVOTest : DescribeSpec({
     lateinit var member: Member

--- a/module-domain/src/test/kotlin/site/yourevents/guest/domain/GuestVOTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/domain/GuestVOTest.kt
@@ -2,7 +2,6 @@ package site.yourevents.guest.domain
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Assertions.*
 import site.yourevents.invitation.domain.Invitation
 import site.yourevents.member.domain.Member
 import java.util.*
@@ -11,7 +10,7 @@ class GuestVOTest : DescribeSpec({
     lateinit var member: Member
     lateinit var invitation: Invitation
     lateinit var nickname: String
-    var attendance: Boolean = true
+    var attendance = true
 
     beforeTest {
         val memberId = UUID.randomUUID()
@@ -49,26 +48,6 @@ class GuestVOTest : DescribeSpec({
                     this.invitation shouldBe invitation
                     this.nickname shouldBe nickname
                     this.attendance shouldBe attendance
-                }
-            }
-        }
-
-        context("GuestVO로 변환할 때") {
-            it("from() 메서드를 통해 올바른 GuestVO가 생성되어야 한다") {
-                val originalGuestVO = GuestVO(
-                    member = member,
-                    invitation = invitation,
-                    nickname = nickname,
-                    attendance = attendance
-                )
-
-                val transformedGuestVO = GuestVO.from(originalGuestVO)
-
-                transformedGuestVO.apply {
-                    member shouldBe originalGuestVO.member
-                    invitation shouldBe originalGuestVO.invitation
-                    nickname shouldBe originalGuestVO.nickname
-                    attendance shouldBe originalGuestVO.attendance
                 }
             }
         }

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.confirmVerified
 import io.mockk.*
 import site.yourevents.guest.domain.Guest
+import site.yourevents.guest.domain.GuestVO
 import site.yourevents.guest.port.out.GuestPersistencePort
 import site.yourevents.invitation.domain.Invitation
 import site.yourevents.invitation.port.`in`.InvitationUseCase
@@ -18,53 +19,40 @@ class GuestServiceTest : DescribeSpec({
     lateinit var invitationUseCase: InvitationUseCase
     lateinit var guestService: GuestService
 
-    lateinit var memberId: UUID
-    lateinit var invitationId: UUID
-    lateinit var socialId: String
-    lateinit var nicknameMember: String
-    lateinit var email: String
-    lateinit var guestNickname: String
-    lateinit var qrUrl: String
-
     lateinit var member: Member
     lateinit var invitation: Invitation
+    lateinit var memberId: UUID
+    lateinit var invitationId: UUID
+    lateinit var guestNickname: String
 
-    beforeTest {
+    beforeEach {
         memberId = UUID.randomUUID()
         invitationId = UUID.randomUUID()
-        socialId = "6316"
-        nicknameMember = "seunghyun"
-        email = "seunghyun@naver.com"
-        guestNickname = "jimking1"
-        qrUrl = "http://example.com"
-
+        guestNickname = "GuestNickName"
         member = Member(
             id = memberId,
-            socialId = socialId,
-            nickname = nicknameMember,
-            email = email
+            socialId = "12345678",
+            nickname = "yes!",
+            email = "yes@yes.com"
         )
-
         invitation = Invitation(
             id = invitationId,
             member = member,
-            qrUrl = qrUrl
+            qrUrl = "https://qrUrl.com"
         )
-    }
 
-    beforeAny {
         guestPersistencePort = mockk()
         memberUseCase = mockk()
         invitationUseCase = mockk()
         guestService = GuestService(guestPersistencePort, memberUseCase, invitationUseCase)
+
+        every { memberUseCase.findById(memberId) } returns member
+        every { invitationUseCase.findById(invitationId) } returns invitation
     }
 
     describe("GuestService") {
         context("createGuest() 메서드를 통해서") {
             it("정상적으로 Guest가 생성되어 반환해야 한다.") {
-                every { memberUseCase.findById(memberId) } returns member
-                every { invitationUseCase.findById(invitationId) } returns invitation
-
                 val guestId = UUID.randomUUID()
                 val expectedGuest = Guest(
                     id = guestId,
@@ -73,7 +61,8 @@ class GuestServiceTest : DescribeSpec({
                     nickname = guestNickname,
                     attendance = true
                 )
-                every { guestPersistencePort.save(any()) } returns expectedGuest
+
+                every { guestPersistencePort.save(any<GuestVO>()) } returns expectedGuest
 
                 val result = guestService.createGuest(memberId, invitationId, guestNickname)
 
@@ -81,12 +70,83 @@ class GuestServiceTest : DescribeSpec({
 
                 verify(exactly = 1) { memberUseCase.findById(memberId) }
                 verify(exactly = 1) { invitationUseCase.findById(invitationId) }
-                verify(exactly = 1) { guestPersistencePort.save(match { guestVO ->
-                    guestVO.member == member &&
-                        guestVO.invitation == invitation &&
-                        guestVO.nickname == guestNickname && guestVO.attendance
+                verify(exactly = 1) {
+                    guestPersistencePort.save(match { guestVO: GuestVO ->
+                        guestVO.member == member &&
+                                guestVO.invitation == invitation &&
+                                guestVO.nickname == guestNickname &&
+                                guestVO.attendance
                     })
                 }
+                confirmVerified(memberUseCase, invitationUseCase, guestPersistencePort)
+            }
+        }
+
+        context("respondInvitation 메서드를 통해서") {
+            it("guestId가 null이면 새로운 Guest를 생성한다.") {
+                val attendance = true
+
+                every { guestPersistencePort.save(any<GuestVO>()) } returns Guest(
+                    id = UUID.randomUUID(),
+                    member = member,
+                    invitation = invitation,
+                    nickname = guestNickname,
+                    attendance = attendance
+                )
+
+                guestService.respondInvitation(
+                    guestId = null,
+                    invitationId = invitationId,
+                    memberId = memberId,
+                    nickname = guestNickname,
+                    attendance = attendance
+                )
+
+                verify(exactly = 1) { memberUseCase.findById(memberId) }
+                verify(exactly = 1) { invitationUseCase.findById(invitationId) }
+                verify(exactly = 1) {
+                    guestPersistencePort.save(match { guestVO: GuestVO ->
+                        guestVO.member == member &&
+                                guestVO.invitation == invitation &&
+                                guestVO.nickname == guestNickname &&
+                                guestVO.attendance == attendance
+                    })
+                }
+                confirmVerified(memberUseCase, invitationUseCase, guestPersistencePort)
+            }
+
+            it("guestId가 null이 아니면 기존 Guest의 attendance만 업데이트한다.") {
+                val guestId = UUID.randomUUID()
+                val expectedGuest = Guest(
+                    id = guestId,
+                    member = member,
+                    invitation = invitation,
+                    nickname = guestNickname,
+                    attendance = true
+                )
+
+                every { guestPersistencePort.findById(any()) } returns expectedGuest
+
+                val updatedAttendance = false
+                expectedGuest.updateAttendance(updatedAttendance)
+
+                val slotGuest = slot<Guest>()
+                every { guestPersistencePort.save(capture(slotGuest)) } just runs
+
+                guestService.respondInvitation(
+                    guestId = guestId,
+                    invitationId = invitationId,
+                    memberId = memberId,
+                    nickname = guestNickname,
+                    attendance = updatedAttendance
+                )
+
+                slotGuest.captured.attendance shouldBe updatedAttendance
+
+                verify(exactly = 1) { memberUseCase.findById(memberId) }
+                verify(exactly = 1) { invitationUseCase.findById(invitationId) }
+                verify(exactly = 1) { guestPersistencePort.findById(any()) }
+                verify(exactly = 1) { guestPersistencePort.save(any<Guest>()) }
                 confirmVerified(memberUseCase, invitationUseCase, guestPersistencePort)
             }
         }

--- a/module-independent/src/main/kotlin/site/yourevents/type/ErrorCode.kt
+++ b/module-independent/src/main/kotlin/site/yourevents/type/ErrorCode.kt
@@ -13,5 +13,6 @@ enum class ErrorCode(
     ROLE_FORBIDDEN(403, "ROLE_FORBIDDEN", "접근할 수 있는 권한이 아닙니다."),
     INVITATION_NOT_FOUND(404, "INVITATION_NOT_FOUND", "존재하지 않는 초대장입니다."),
     MEMBER_NOT_FOUND(404, "MEMBER_NOT_FOUND", "존재하지 않는 사용자입니다."),
+    GUEST_NOT_FOUND(404, "GUEST_NOT_FOUND", "존재하지 않는 참가자입니다."),
     INTERNAL_SERVER_ERROR(500, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."),
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/entity/GuestEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/entity/GuestEntity.kt
@@ -1,6 +1,5 @@
 package site.yourevents.guest.entity
 
-import jakarta.persistence.CascadeType
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -5,6 +5,8 @@ import site.yourevents.guest.domain.Guest
 import site.yourevents.guest.domain.GuestVO
 import site.yourevents.guest.entity.GuestEntity
 import site.yourevents.guest.port.out.GuestPersistencePort
+import java.util.UUID
+import kotlin.jvm.optionals.getOrNull
 
 @Repository
 class GuestRepository(
@@ -13,5 +15,14 @@ class GuestRepository(
     override fun save(guestVo: GuestVO): Guest {
         return guestJPARepository.save(GuestEntity.from(guestVo))
             .toDomain()
+    }
+
+    override fun save(guest: Guest) {
+        guestJPARepository.save(GuestEntity.from(guest))
+    }
+
+    override fun findById(guestId: UUID): Guest? {
+        return guestJPARepository.findById(guestId)
+            .getOrNull()?.toDomain()
     }
 }

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/guest/repository/GuestRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/guest/repository/GuestRepositoryTest.kt
@@ -22,7 +22,6 @@ class GuestRepositoryTest(
     @Autowired private val memberJPARepository: MemberJPARepository,
     @Autowired private val invitationJPARepository: InvitationJPARepository
 ) : DescribeSpec({
-
     val guestRepository = GuestRepository(guestJPARepository)
 
     lateinit var guestVO: GuestVO
@@ -60,14 +59,16 @@ class GuestRepositoryTest(
     }
 
     describe("GuestRepository") {
-        it("save() 메서드를 통해 Guest를 저장하고 반환해야 한다") {
-            val savedGuest = guestRepository.save(guestVO)
+        context("save() 메서드에서") {
+            it("GuestVO를 저장하고 반환해야 한다") {
+                val savedGuest = guestRepository.save(guestVO)
 
-            savedGuest.nickname shouldBe guestVO.nickname
-            savedGuest.attendance shouldBe guestVO.attendance
+                savedGuest.nickname shouldBe guestVO.nickname
+                savedGuest.attendance shouldBe guestVO.attendance
 
-            savedGuest.member.getSocialId() shouldBe memberEntity.toDomain().getSocialId()
-            savedGuest.invitation.id shouldBe invitationEntity.id
+                savedGuest.member.getSocialId() shouldBe memberEntity.toDomain().getSocialId()
+                savedGuest.invitation.id shouldBe invitationEntity.id
+            }
         }
     }
 })

--- a/module-presentation/src/main/kotlin/site/yourevents/guest/api/GuestApi.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/guest/api/GuestApi.kt
@@ -1,0 +1,20 @@
+package site.yourevents.guest.api
+
+import io.swagger.v3.oas.annotations.Operation
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import site.yourevents.guest.dto.request.InvitationRespondRequest
+import site.yourevents.principal.AuthDetails
+import site.yourevents.response.ApiResponse
+
+@RequestMapping("/guest")
+interface GuestApi {
+    @Operation(summary = "초대 응답")
+    @PatchMapping("/respond")
+    fun respondInvitation(
+        @RequestBody invitationRespondRequest: InvitationRespondRequest,
+        @AuthenticationPrincipal authDetails: AuthDetails
+    ): ApiResponse<Unit>
+}

--- a/module-presentation/src/main/kotlin/site/yourevents/guest/api/GuestController.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/guest/api/GuestController.kt
@@ -1,0 +1,22 @@
+package site.yourevents.guest.api
+
+import org.springframework.web.bind.annotation.RestController
+import site.yourevents.guest.dto.request.InvitationRespondRequest
+import site.yourevents.guest.facade.GuestFacade
+import site.yourevents.principal.AuthDetails
+import site.yourevents.response.ApiResponse
+import site.yourevents.type.SuccessCode
+
+@RestController
+class GuestController(
+    private val guestFacade: GuestFacade,
+) : GuestApi {
+    override fun respondInvitation(
+        invitationRespondRequest: InvitationRespondRequest,
+        authDetails: AuthDetails
+    ): ApiResponse<Unit> {
+        guestFacade.respondInvitation(invitationRespondRequest, authDetails)
+
+        return ApiResponse.success(SuccessCode.REQUEST_OK)
+    }
+}

--- a/module-presentation/src/main/kotlin/site/yourevents/guest/dto/request/InvitationRespondRequest.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/guest/dto/request/InvitationRespondRequest.kt
@@ -1,0 +1,10 @@
+package site.yourevents.guest.dto.request
+
+import java.util.UUID
+
+data class InvitationRespondRequest(
+    val guestId: UUID?,
+    val invitationId: UUID,
+    val nickname: String,
+    val attendance: Boolean,
+)

--- a/module-presentation/src/main/kotlin/site/yourevents/guest/facade/GuestFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/guest/facade/GuestFacade.kt
@@ -1,0 +1,26 @@
+package site.yourevents.guest.facade
+
+import org.springframework.stereotype.Service
+import site.yourevents.guest.dto.request.InvitationRespondRequest
+import site.yourevents.guest.port.`in`.GuestUseCase
+import site.yourevents.principal.AuthDetails
+
+@Service
+class GuestFacade(
+    private val guestUseCase: GuestUseCase
+) {
+    fun respondInvitation(
+        invitationRespondRequest: InvitationRespondRequest,
+        authDetails: AuthDetails
+    ) {
+        val memberId = authDetails.uuid
+
+        guestUseCase.respondInvitation(
+            invitationRespondRequest.guestId,
+            invitationRespondRequest.invitationId,
+            memberId,
+            invitationRespondRequest.nickname,
+            invitationRespondRequest.attendance,
+        )
+    }
+}

--- a/module-presentation/src/test/kotlin/site/yourevents/config/WithCustomMockkMember.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/config/WithCustomMockkMember.kt
@@ -1,0 +1,10 @@
+/*
+package site.yourevents.config
+
+import org.springframework.security.test.context.support.WithSecurityContext
+import kotlin.annotation.AnnotationRetention.RUNTIME
+
+@Retention(RUNTIME)
+@WithSecurityContext(factory = WithCustomMockkMemberSecurityContextFactory::class)
+annotation class WithCustomMockkMember()
+*/

--- a/module-presentation/src/test/kotlin/site/yourevents/config/WithCustomMockkMemberSecurityContextFactory.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/config/WithCustomMockkMemberSecurityContextFactory.kt
@@ -1,0 +1,35 @@
+/*
+package site.yourevents.config
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithSecurityContextFactory
+import site.yourevents.principal.AuthDetails
+import java.util.*
+
+
+class WithCustomMockkMemberSecurityContextFactory
+    : WithSecurityContextFactory<WithCustomMockkMember> {
+    override fun createSecurityContext(annotation: WithCustomMockkMember): SecurityContext {
+        val memberId = UUID.randomUUID()
+        val socialId = "12345678"
+        val role = "ROLE_USER"
+
+        val authDetails = AuthDetails(
+            uuid = memberId,
+            socialId = socialId,
+            role = role
+        )
+
+        val token = UsernamePasswordAuthenticationToken(
+            authDetails, null, listOf(SimpleGrantedAuthority(role))
+        )
+        val context = SecurityContextHolder.getContext().apply {
+            authentication = token
+        }
+
+        return context
+    }
+}*/

--- a/module-presentation/src/test/kotlin/site/yourevents/guest/facade/GuestFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/guest/facade/GuestFacadeTest.kt
@@ -1,0 +1,57 @@
+package site.yourevents.guest.facade
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import site.yourevents.guest.dto.request.InvitationRespondRequest
+import site.yourevents.guest.port.`in`.GuestUseCase
+import site.yourevents.principal.AuthDetails
+import java.util.*
+
+class GuestFacadeTest : DescribeSpec({
+    val guestUseCase: GuestUseCase = mockk()
+    val guestFacade = GuestFacade(guestUseCase)
+
+    describe("GuestFacade") {
+        context("respondInvitation 메서드 호출 시") {
+            it("GuestUseCase.respondInvitation()가 정확히 한 번 호출된다.") {
+                every {
+                    guestUseCase.respondInvitation(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()
+                    )
+                } returns Unit
+
+                val request = InvitationRespondRequest(
+                    guestId = UUID.randomUUID(),
+                    invitationId = UUID.randomUUID(),
+                    nickname = "nickname",
+                    attendance = true
+                )
+                val authDetails = AuthDetails(
+                    uuid = UUID.randomUUID(),
+                    socialId = "socialId",
+                    role = "ROLE_USER"
+                )
+
+                guestFacade.respondInvitation(request, authDetails)
+
+                verify(exactly = 1) {
+                    guestUseCase.respondInvitation(
+                        any(),
+                        any(),
+                        any(),
+                        any(),
+                        any()
+                    )
+                }
+                confirmVerified(guestUseCase)
+            }
+        }
+    }
+})

--- a/module-presentation/src/test/kotlin/site/yourevents/guest/facade/GuestFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/guest/facade/GuestFacadeTest.kt
@@ -3,7 +3,9 @@ package site.yourevents.guest.facade
 import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.confirmVerified
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import site.yourevents.guest.dto.request.InvitationRespondRequest
 import site.yourevents.guest.port.`in`.GuestUseCase
@@ -25,7 +27,7 @@ class GuestFacadeTest : DescribeSpec({
                         any(),
                         any()
                     )
-                } returns Unit
+                } just runs
 
                 val request = InvitationRespondRequest(
                     guestId = UUID.randomUUID(),


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용
### Request DTO
```kotlin
data class InvitationRespondRequest(
    val guestId: UUID?,
    val invitationId: UUID,
    val nickname: String,
    val attendance: Boolean,
)
```
기존 초대 객체를 판별하는 여부를 담당하는 guestId를 비롯하여
초대장 Id, 초대받은 사람의 닉네임, 출석 여부를 담고 있습니다.

### 비즈니스 로직
- guestId를 Nullable로 입력받아 분기점으로 활용합니다.
  - 존재할 경우: Id를 통해 Guest 엔티티를 조회, 출석을 수정
  - 존재하지 않는 경우: DTO를 기반으로 새로운 객체 생성
```kotlin
if (guestId == null) {
            guestPersistencePort.save(
                GuestVO(
                    member = member,
                    invitation = invitation,
                    nickname = nickname,
                    attendance = attendance
                )
            )
            return
        }
        updateAttendance(guestId, attendance)
```

---

## 🔗 관련 이슈
- closes #16 

---

## 💡 추가 사항
- Docker 관련 오류로 인해 스크린샷 첨부가 현재 어려운 상황입니다..ㅠㅠ
- SecurityContext 관련하여 Controller 테스트 코드 작성에 문제가 있어 현재 보류해둔 상황입니다~!!
