### PR TITLE
feat: 초대장 수락 여부 확인 기능 구현

### DIFF
--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -32,5 +32,5 @@ interface GuestUseCase {
 
     fun getNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
-    fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean
+    fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -31,4 +31,6 @@ interface GuestUseCase {
     fun getAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
     fun getNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
+
+    fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -21,5 +21,5 @@ interface GuestPersistencePort {
 
     fun findNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
-    fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest?
+    fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -20,4 +20,6 @@ interface GuestPersistencePort {
     fun findAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
     fun findNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
+
+    fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -21,5 +21,5 @@ interface GuestPersistencePort {
 
     fun findNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
-    fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
+    fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -21,5 +21,5 @@ interface GuestPersistencePort {
 
     fun findNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
-    fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest
+    fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -8,7 +8,6 @@ import site.yourevents.guest.exception.GuestNotFoundException
 import site.yourevents.guest.port.`in`.GuestUseCase
 import site.yourevents.guest.port.out.GuestPersistencePort
 import site.yourevents.invitation.domain.Invitation
-import site.yourevents.invitation.exception.InvitationNotFoundException
 import site.yourevents.invitation.port.`in`.InvitationUseCase
 import site.yourevents.member.domain.Member
 import site.yourevents.member.exception.MemberNotFountException
@@ -82,10 +81,8 @@ class GuestService(
         return guestPersistencePort.findNotAttendGuestsByInvitation(invitation)
     }
 
-    override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? {
-        val guest = guestPersistencePort.findByMemberAndInvitation(memberId, invitationId)
-        return guest
-    }
+    override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? =
+        guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId)
 
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {
         val guest = guestPersistencePort.findById(guestId)

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -8,6 +8,7 @@ import site.yourevents.guest.exception.GuestNotFoundException
 import site.yourevents.guest.port.`in`.GuestUseCase
 import site.yourevents.guest.port.out.GuestPersistencePort
 import site.yourevents.invitation.domain.Invitation
+import site.yourevents.invitation.exception.InvitationNotFoundException
 import site.yourevents.invitation.port.`in`.InvitationUseCase
 import site.yourevents.member.domain.Member
 import site.yourevents.member.exception.MemberNotFountException
@@ -81,9 +82,9 @@ class GuestService(
         return guestPersistencePort.findNotAttendGuestsByInvitation(invitation)
     }
 
-    override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean {
-        val guest = guestPersistencePort.findByMemberAndInvitation(memberId,invitationId)
-        return guest.attendance
+    override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? {
+        val guest = guestPersistencePort.findByMemberAndInvitation(memberId, invitationId)
+        return guest?.attendance
     }
 
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -84,7 +84,7 @@ class GuestService(
 
     override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? {
         val guest = guestPersistencePort.findByMemberAndInvitation(memberId, invitationId)
-        return guest?.attendance
+        return guest
     }
 
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -81,6 +81,11 @@ class GuestService(
         return guestPersistencePort.findNotAttendGuestsByInvitation(invitation)
     }
 
+    override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean {
+        val guest = guestPersistencePort.findByMemberAndInvitation(memberId,invitationId)
+        return guest.attendance
+    }
+
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {
         val guest = guestPersistencePort.findById(guestId)
             ?: throw GuestNotFoundException()

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -312,5 +312,49 @@ class GuestServiceTest : DescribeSpec({
                 confirmVerified(guestPersistencePort)
             }
         }
+
+        context("getInvitationAttendance 메서드를 통해서") {
+            it("참석 여부가 true로 반환되어야 한다") {
+                val isAttending = true
+
+                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns Guest(
+                    id = UUID.randomUUID(),
+                    member = member,
+                    invitation = invitation,
+                    nickname = "nickname",
+                    attendance = isAttending,
+                    createdAt = LocalDateTime.now(),
+                    modifiedAt = LocalDateTime.now()
+                )
+
+                val result = guestService.getInvitationAttendance(memberId, invitationId)
+
+                result shouldBe isAttending
+
+                verify(exactly = 1) { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) }
+                confirmVerified(guestPersistencePort)
+            }
+
+            it("참석 여부가 false로 반환되어야 한다") {
+                val isAttending = false
+
+                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns Guest(
+                    id = UUID.randomUUID(),
+                    member = member,
+                    invitation = invitation,
+                    nickname = "nickname",
+                    attendance = isAttending,
+                    createdAt = LocalDateTime.now(),
+                    modifiedAt = LocalDateTime.now()
+                )
+
+                val result = guestService.getInvitationAttendance(memberId, invitationId)
+
+                result shouldBe isAttending
+
+                verify(exactly = 1) { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) }
+                confirmVerified(guestPersistencePort)
+            }
+        }
     }
 })

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -317,26 +317,26 @@ class GuestServiceTest : DescribeSpec({
             it("참석 여부가 true로 반환되어야 한다") {
                 val isAttending = true
 
-                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns isAttending
+                every { guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId) } returns isAttending
 
                 val result = guestService.getInvitationAttendance(memberId, invitationId)
 
                 result shouldBe isAttending
 
-                verify(exactly = 1) { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) }
+                verify(exactly = 1) { guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId) }
                 confirmVerified(guestPersistencePort)
             }
 
             it("참석 여부가 false로 반환되어야 한다") {
                 val isAttending = false
 
-                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns isAttending
+                every { guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId) } returns isAttending
 
                 val result = guestService.getInvitationAttendance(memberId, invitationId)
 
                 result shouldBe isAttending
 
-                verify(exactly = 1) { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) }
+                verify(exactly = 1) { guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId) }
                 confirmVerified(guestPersistencePort)
             }
         }

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -317,15 +317,7 @@ class GuestServiceTest : DescribeSpec({
             it("참석 여부가 true로 반환되어야 한다") {
                 val isAttending = true
 
-                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns Guest(
-                    id = UUID.randomUUID(),
-                    member = member,
-                    invitation = invitation,
-                    nickname = "nickname",
-                    attendance = isAttending,
-                    createdAt = LocalDateTime.now(),
-                    modifiedAt = LocalDateTime.now()
-                )
+                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns isAttending
 
                 val result = guestService.getInvitationAttendance(memberId, invitationId)
 
@@ -338,15 +330,7 @@ class GuestServiceTest : DescribeSpec({
             it("참석 여부가 false로 반환되어야 한다") {
                 val isAttending = false
 
-                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns Guest(
-                    id = UUID.randomUUID(),
-                    member = member,
-                    invitation = invitation,
-                    nickname = "nickname",
-                    attendance = isAttending,
-                    createdAt = LocalDateTime.now(),
-                    modifiedAt = LocalDateTime.now()
-                )
+                every { guestPersistencePort.findByMemberAndInvitation(memberId, invitationId) } returns isAttending
 
                 val result = guestService.getInvitationAttendance(memberId, invitationId)
 

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -263,7 +263,7 @@ class GuestServiceTest : DescribeSpec({
                 confirmVerified(memberUseCase, invitationUseCase, guestPersistencePort)
             }
         }
-        context("getGuestsByInvitation() 메서드를 통해서") {
+        context("findAttendGuestsByInvitation, findNotAttendGuestsByInvitation 메서드를 통해서") {
             it("참석하는 게스트와 참석하지 않는 게스트 목록이 반환되어야 한다.") {
                 val attendingGuest1 = Guest(
                     id = UUID.randomUUID(),

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -40,4 +40,7 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
                 "AND g.attendance = false " +
                 "AND g.invitation.deleted = false")
     fun findNotAttendGuestsByInvitation(invitationEntity: InvitationEntity): List<GuestEntity>
+
+    @Query("SELECT g FROM guest g WHERE g.member.id = :memberId AND g.invitation.id = :invitationId")
+    fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): GuestEntity
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -41,6 +41,9 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
                 "AND g.invitation.deleted = false")
     fun findNotAttendGuestsByInvitation(invitationEntity: InvitationEntity): List<GuestEntity>
 
-    @Query("SELECT g.attendance FROM guest g WHERE g.member.id = :memberId AND g.invitation.id = :invitationId")
+    @Query("SELECT g.attendance " +
+        "FROM guest g " +
+        "WHERE g.member.id = :memberId " +
+        "AND g.invitation.id = :invitationId")
     fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): Boolean?
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -41,6 +41,6 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
                 "AND g.invitation.deleted = false")
     fun findNotAttendGuestsByInvitation(invitationEntity: InvitationEntity): List<GuestEntity>
 
-    @Query("SELECT g FROM guest g WHERE g.member.id = :memberId AND g.invitation.id = :invitationId")
-    fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): GuestEntity?
+    @Query("SELECT g.attendance FROM guest g WHERE g.member.id = :memberId AND g.invitation.id = :invitationId")
+    fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): Boolean?
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -45,5 +45,5 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
         "FROM guest g " +
         "WHERE g.member.id = :memberId " +
         "AND g.invitation.id = :invitationId")
-    fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): Boolean?
+    fun findAttendanceByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): Boolean?
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -42,5 +42,5 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
     fun findNotAttendGuestsByInvitation(invitationEntity: InvitationEntity): List<GuestEntity>
 
     @Query("SELECT g FROM guest g WHERE g.member.id = :memberId AND g.invitation.id = :invitationId")
-    fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): GuestEntity
+    fun findByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): GuestEntity?
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -46,7 +46,7 @@ class GuestRepository(
             .map(GuestEntity::toDomain)
     }
 
-    override fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean? {
-        return guestJPARepository.findByMemberIdAndInvitationId(memberId, invitationId)
+    override fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean? {
+        return guestJPARepository.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
     }
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -46,8 +46,7 @@ class GuestRepository(
             .map(GuestEntity::toDomain)
     }
 
-    override fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest? {
+    override fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean? {
         return guestJPARepository.findByMemberIdAndInvitationId(memberId, invitationId)
-            ?.toDomain()
     }
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -45,4 +45,9 @@ class GuestRepository(
         return guestJPARepository.findNotAttendGuestsByInvitation(InvitationEntity.from(invitation))
             .map(GuestEntity::toDomain)
     }
+
+    override fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest {
+        return guestJPARepository.findByMemberIdAndInvitationId(memberId, invitationId)
+            .toDomain()
+    }
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -46,8 +46,8 @@ class GuestRepository(
             .map(GuestEntity::toDomain)
     }
 
-    override fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest {
+    override fun findByMemberAndInvitation(memberId: UUID, invitationId: UUID): Guest? {
         return guestJPARepository.findByMemberIdAndInvitationId(memberId, invitationId)
-            .toDomain()
+            ?.toDomain()
     }
 }

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationApi.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationApi.kt
@@ -10,10 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import site.yourevents.invitation.dto.request.CreateInvitationRequest
-import site.yourevents.invitation.dto.response.CreateInvitationResponse
-import site.yourevents.invitation.dto.response.InvitationGuestResponse
-import site.yourevents.invitation.dto.response.InvitationInfoResponse
-import site.yourevents.invitation.dto.response.InvitationQrResponse
+import site.yourevents.invitation.dto.response.*
 import site.yourevents.principal.AuthDetails
 import site.yourevents.response.ApiResponse
 import java.util.UUID
@@ -51,4 +48,11 @@ interface InvitationApi {
     fun getGuestsByInvitation(
         @PathVariable invitationId: UUID
     ): ApiResponse<InvitationGuestResponse>
+
+    @Operation(summary = "특정 초대장에 대한 본인 참석 여부 조회")
+    @GetMapping("/{invitationId}/attendance")
+    fun getInvitationAttendance(
+        @PathVariable invitationId: UUID,
+        @AuthenticationPrincipal authDetails: AuthDetails
+    ): ApiResponse<InvitationAttendanceResponse>
 }

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationController.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationController.kt
@@ -55,7 +55,7 @@ class InvitationController(
         @PathVariable invitationId: UUID,
         @AuthenticationPrincipal authDetails: AuthDetails
     ): ApiResponse<InvitationAttendanceResponse> = ApiResponse.success(
-        SuccessCode.REQUEST_OK, invitationFacade.getInvitationAttendance(invitationId, authDetails.uuid)
+        SuccessCode.REQUEST_OK, invitationFacade.getInvitationAttendance(invitationId, authDetails)
     )
           
     override fun verifySender(

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationController.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationController.kt
@@ -56,6 +56,7 @@ class InvitationController(
         @AuthenticationPrincipal authDetails: AuthDetails
     ): ApiResponse<InvitationAttendanceResponse> = ApiResponse.success(
         SuccessCode.REQUEST_OK, invitationFacade.getInvitationAttendance(invitationId, authDetails.uuid)
+    )
           
     override fun verifySender(
         @PathVariable invitationId: UUID,

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationController.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/api/InvitationController.kt
@@ -6,10 +6,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import site.yourevents.invitation.dto.request.CreateInvitationRequest
-import site.yourevents.invitation.dto.response.CreateInvitationResponse
-import site.yourevents.invitation.dto.response.InvitationGuestResponse
-import site.yourevents.invitation.dto.response.InvitationInfoResponse
-import site.yourevents.invitation.dto.response.InvitationQrResponse
+import site.yourevents.invitation.dto.response.*
 import site.yourevents.invitation.facade.InvitationFacade
 import site.yourevents.principal.AuthDetails
 import site.yourevents.response.ApiResponse
@@ -52,5 +49,12 @@ class InvitationController(
         @PathVariable invitationId: UUID
     ): ApiResponse<InvitationGuestResponse> = ApiResponse.success(
         SuccessCode.REQUEST_OK, invitationFacade.getInvitationGuests(invitationId)
+    )
+
+    override fun getInvitationAttendance(
+        @PathVariable invitationId: UUID,
+        @AuthenticationPrincipal authDetails: AuthDetails
+    ): ApiResponse<InvitationAttendanceResponse> = ApiResponse.success(
+        SuccessCode.REQUEST_OK, invitationFacade.getInvitationAttendance(invitationId, authDetails.uuid)
     )
 }

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/request/CreateInvitationRequest.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/request/CreateInvitationRequest.kt
@@ -3,23 +3,10 @@ package site.yourevents.invitation.dto.request
 import java.time.LocalDateTime
 
 data class CreateInvitationRequest(
-    val owner: GuestRequestDto,
-    val invitationThumbnail: InvitationThumbnailRequestDto,
-    val invitationInformation: InvitationInformationRequestDto
-) {
-
-    data class GuestRequestDto(
-        val nickname: String,
-    )
-
-    data class InvitationThumbnailRequestDto(
-        val thumbnailUrl: String
-    )
-
-    data class InvitationInformationRequestDto(
-        val title: String,
-        val schedule: LocalDateTime,
-        val location: String,
-        val remark: String,
-    )
-}
+    val ownerNickname: String,
+    val thumbnailUrl: String,
+    val title: String,
+    val schedule: LocalDateTime,
+    val location: String,
+    val remark: String
+)

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
@@ -5,5 +5,5 @@ import java.util.UUID
 data class InvitationAttendanceResponse(
     val invitationId: UUID,
     val memberId: UUID,
-    val attendance: Boolean
+    val attendance: Boolean?
 )

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
@@ -1,0 +1,9 @@
+package site.yourevents.invitation.dto.response
+
+import java.util.UUID
+
+data class InvitationAttendanceResponse(
+    val invitationId: UUID,
+    val memberId: UUID,
+    val attendance: Boolean
+)

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -10,6 +10,7 @@ import site.yourevents.invitation.port.`in`.InvitationUseCase
 import site.yourevents.invitationinformation.port.`in`.InvitationInformationUseCase
 import site.yourevents.invitationthumnail.port.`in`.InvitationThumbnailUseCase
 import site.yourevents.principal.AuthDetails
+import java.time.LocalDateTime
 import java.util.UUID
 
 @Service
@@ -30,11 +31,17 @@ class InvitationFacade(
 
         val invitation = invitationUseCase.updateQrCode(generateInvitation(memberId).id)
 
-        val owner = generateOwner(memberId, invitation.id, createInvitationRequest)
+        val owner = generateOwner(memberId, invitation.id, createInvitationRequest.ownerNickname)
 
-        val invitationThumbnail = generateInvitationThumbnail(invitation.id, createInvitationRequest)
+        val invitationThumbnail = generateInvitationThumbnail(invitation.id, createInvitationRequest.thumbnailUrl)
 
-        val invitationInformation = generateInvitationInformation(invitation.id, createInvitationRequest)
+        val invitationInformation = generateInvitationInformation(
+            invitation.id,
+            title = createInvitationRequest.title,
+            schedule = createInvitationRequest.schedule,
+            location = createInvitationRequest.location,
+            remark = createInvitationRequest.remark
+        )
 
         return CreateInvitationResponse.of(invitation, owner, invitationThumbnail, invitationInformation)
     }
@@ -96,25 +103,30 @@ class InvitationFacade(
     private fun generateInvitation(memberId: UUID) =
         invitationUseCase.createInvitation(memberId, null.toString())
 
-    private fun generateOwner(memberId: UUID, invitationId: UUID, request: CreateInvitationRequest) =
+    private fun generateOwner(memberId: UUID, invitationId: UUID, ownerNickname: String) =
         guestUseCase.createGuest(
             memberId = memberId,
             invitationId = invitationId,
-            nickname = request.owner.nickname
+            nickname = ownerNickname
         )
 
-    private fun generateInvitationThumbnail(invitationId: UUID, request: CreateInvitationRequest) =
+    private fun generateInvitationThumbnail(invitationId: UUID, thumbUrl: String ) =
         invitationThumbnailUseCase.createInvitationThumbnail(
             invitationId = invitationId,
-            url = request.invitationThumbnail.thumbnailUrl
+            url = thumbUrl
         )
 
-    private fun generateInvitationInformation(invitationId: UUID, request: CreateInvitationRequest) =
-        invitationInformationUseCase.createInvitationInformation(
+    private fun generateInvitationInformation(
+        invitationId: UUID,
+        title: String,
+        schedule: LocalDateTime,
+        location: String,
+        remark: String
+    ) = invitationInformationUseCase.createInvitationInformation(
             invitationId = invitationId,
-            title = request.invitationInformation.title,
-            schedule = request.invitationInformation.schedule,
-            location = request.invitationInformation.location,
-            remark = request.invitationInformation.remark
+            title = title,
+            schedule = schedule,
+            location = location,
+            remark = remark
         )
 }

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -81,7 +81,6 @@ class InvitationFacade(
     }
 
     fun getInvitationAttendance(invitationId: UUID, memberId: UUID): InvitationAttendanceResponse{
-        val invitation = invitationUseCase.findById(invitationId)
         val invitationAttendance = guestUseCase.getInvitationAttendance(memberId, invitationId)
 
         return InvitationAttendanceResponse(

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -87,7 +87,9 @@ class InvitationFacade(
         )
     }
 
-    fun getInvitationAttendance(invitationId: UUID, memberId: UUID): InvitationAttendanceResponse{
+    fun getInvitationAttendance(invitationId: UUID, authDetails: AuthDetails): InvitationAttendanceResponse
+    {
+        val memberId = authDetails.uuid
         val invitationAttendance = guestUseCase.getInvitationAttendance(memberId, invitationId)
 
         return InvitationAttendanceResponse(
@@ -110,7 +112,7 @@ class InvitationFacade(
             nickname = ownerNickname
         )
 
-    private fun generateInvitationThumbnail(invitationId: UUID, invitationThumbUrl: String ) =
+    private fun generateInvitationThumbnail(invitationId: UUID, invitationThumbUrl: String) =
         invitationThumbnailUseCase.createInvitationThumbnail(
             invitationId = invitationId,
             url = invitationThumbUrl

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -110,10 +110,10 @@ class InvitationFacade(
             nickname = ownerNickname
         )
 
-    private fun generateInvitationThumbnail(invitationId: UUID, thumbUrl: String ) =
+    private fun generateInvitationThumbnail(invitationId: UUID, invitationThumbUrl: String ) =
         invitationThumbnailUseCase.createInvitationThumbnail(
             invitationId = invitationId,
-            url = thumbUrl
+            url = invitationThumbUrl
         )
 
     private fun generateInvitationInformation(

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -4,10 +4,7 @@ import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import site.yourevents.guest.port.`in`.GuestUseCase
 import site.yourevents.invitation.dto.request.CreateInvitationRequest
-import site.yourevents.invitation.dto.response.CreateInvitationResponse
-import site.yourevents.invitation.dto.response.InvitationGuestResponse
-import site.yourevents.invitation.dto.response.InvitationInfoResponse
-import site.yourevents.invitation.dto.response.InvitationQrResponse
+import site.yourevents.invitation.dto.response.*
 import site.yourevents.invitation.exception.UnauthorizedException
 import site.yourevents.invitation.port.`in`.InvitationUseCase
 import site.yourevents.invitationinformation.port.`in`.InvitationInformationUseCase
@@ -80,6 +77,17 @@ class InvitationFacade(
         return InvitationGuestResponse(
             attending = attend,
             notAttending = notAttend
+        )
+    }
+
+    fun getInvitationAttendance(invitationId: UUID, memberId: UUID): InvitationAttendanceResponse{
+        val invitation = invitationUseCase.findById(invitationId)
+        val invitationAttendance = guestUseCase.getInvitationAttendance(memberId, invitationId)
+
+        return InvitationAttendanceResponse(
+            invitationId = invitationId,
+            memberId = memberId,
+            attendance = invitationAttendance
         )
     }
 

--- a/module-presentation/src/main/resources/application-dev.yml
+++ b/module-presentation/src/main/resources/application-dev.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -226,7 +226,6 @@ class InvitationFacadeTest : DescribeSpec({
                 val isAttending = true
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
-                every { invitationUseCase.findById(invitationId) } returns invitation
 
                 val response = invitationFacade.getInvitationAttendance(invitationId, memberId)
 
@@ -234,7 +233,6 @@ class InvitationFacadeTest : DescribeSpec({
                 response.memberId shouldBe memberId
                 response.attendance shouldBe isAttending
 
-                verify(exactly = 1) { invitationUseCase.findById(invitationId) }
                 verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
                 confirmVerified(invitationUseCase, guestUseCase)
             }
@@ -243,7 +241,6 @@ class InvitationFacadeTest : DescribeSpec({
                 val isAttending = false
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
-                every { invitationUseCase.findById(invitationId) } returns invitation
 
                 val response = invitationFacade.getInvitationAttendance(invitationId, memberId)
 
@@ -251,7 +248,6 @@ class InvitationFacadeTest : DescribeSpec({
                 response.memberId shouldBe memberId
                 response.attendance shouldBe isAttending
 
-                verify(exactly = 1) { invitationUseCase.findById(invitationId) }
                 verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
                 confirmVerified(invitationUseCase, guestUseCase)
             }

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -220,6 +220,6 @@ class InvitationFacadeTest : DescribeSpec({
                 verify(exactly = 1) { guestUseCase.getNotAttendGuestsByInvitation(invitation) }
                 confirmVerified(guestUseCase)
             }
-            }
+        }
     }
 })

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -226,7 +226,7 @@ class InvitationFacadeTest : DescribeSpec({
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
 
-                val response = invitationFacade.getInvitationAttendance(invitationId, memberId)
+                val response = invitationFacade.getInvitationAttendance(invitationId, authDetails)
 
                 response.invitationId shouldBe invitationId
                 response.memberId shouldBe memberId
@@ -241,7 +241,7 @@ class InvitationFacadeTest : DescribeSpec({
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
 
-                val response = invitationFacade.getInvitationAttendance(invitationId, memberId)
+                val response = invitationFacade.getInvitationAttendance(invitationId, authDetails)
 
                 response.invitationId shouldBe invitationId
                 response.memberId shouldBe memberId

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -45,14 +45,12 @@ class InvitationFacadeTest : DescribeSpec({
         )
 
         val createInvitationRequest = CreateInvitationRequest(
-            owner = CreateInvitationRequest.GuestRequestDto(nickname = "nickname"),
-            invitationThumbnail = CreateInvitationRequest.InvitationThumbnailRequestDto(thumbnailUrl = "http://example.com/"),
-            invitationInformation = CreateInvitationRequest.InvitationInformationRequestDto(
-                title = "title",
-                schedule = LocalDateTime.now(),
-                location = "location",
-                remark = "remark"
-            )
+            ownerNickname = "nickname",
+            thumbnailUrl = "http://example.com/",
+            title = "title",
+            schedule = LocalDateTime.now(),
+            location = "location",
+            remark = "remark"
         )
 
         val member = Member(
@@ -79,7 +77,7 @@ class InvitationFacadeTest : DescribeSpec({
             id = ownerId,
             member = member,
             invitation = invitation,
-            nickname = createInvitationRequest.owner.nickname,
+            nickname = createInvitationRequest.ownerNickname,
             attendance = true,
             createdAt = LocalDateTime.now(),
             modifiedAt = LocalDateTime.now()
@@ -88,7 +86,7 @@ class InvitationFacadeTest : DescribeSpec({
         val invitationThumbnail = InvitationThumbnail(
             id = thumbnailId,
             invitation = invitation,
-            url = createInvitationRequest.invitationThumbnail.thumbnailUrl,
+            url = createInvitationRequest.thumbnailUrl,
             createdAt = LocalDateTime.now(),
             modifiedAt = LocalDateTime.now()
         )
@@ -96,10 +94,10 @@ class InvitationFacadeTest : DescribeSpec({
         val invitationInformation = InvitationInformation(
             id = informationId,
             invitation = invitation,
-            title = createInvitationRequest.invitationInformation.title,
-            schedule = createInvitationRequest.invitationInformation.schedule,
-            location = createInvitationRequest.invitationInformation.location,
-            remark = createInvitationRequest.invitationInformation.remark,
+            title = createInvitationRequest.title,
+            schedule = createInvitationRequest.schedule,
+            location = createInvitationRequest.location,
+            remark = createInvitationRequest.remark,
             createdAt = LocalDateTime.now(),
             modifiedAt = LocalDateTime.now()
         )

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -221,5 +221,40 @@ class InvitationFacadeTest : DescribeSpec({
                 confirmVerified(guestUseCase)
             }
         }
+        context("getInvitationAttendance 메서드가 호출되었을 때") {
+            it("참석 여부가 true로 반환되어야 한다") {
+                val isAttending = true
+
+                every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
+                every { invitationUseCase.findById(invitationId) } returns invitation
+
+                val response = invitationFacade.getInvitationAttendance(invitationId, memberId)
+
+                response.invitationId shouldBe invitationId
+                response.memberId shouldBe memberId
+                response.attendance shouldBe isAttending
+
+                verify(exactly = 1) { invitationUseCase.findById(invitationId) }
+                verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
+                confirmVerified(invitationUseCase, guestUseCase)
+            }
+
+            it("참석 여부가 false로 반환되어야 한다") {
+                val isAttending = false
+
+                every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
+                every { invitationUseCase.findById(invitationId) } returns invitation
+
+                val response = invitationFacade.getInvitationAttendance(invitationId, memberId)
+
+                response.invitationId shouldBe invitationId
+                response.memberId shouldBe memberId
+                response.attendance shouldBe isAttending
+
+                verify(exactly = 1) { invitationUseCase.findById(invitationId) }
+                verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
+                confirmVerified(invitationUseCase, guestUseCase)
+            }
+        }
     }
 })


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용
**현재 로그인한 사용자가 특정 초대장에 대해 참석을 수락하였는지 여부를 확인하는 기능을 구현하였습니다.**
**ResponseDTO를 통해 해당 초대장의 id, 멤버의 id(결국 본인), 수락 여부가 반환되도록 하였습니다.**
![image](https://github.com/user-attachments/assets/a585277b-90d7-4e28-be2c-94935f6ec539)


---

## 🔗 관련 이슈
- closes #3

---

## 💡 추가 사항

