### PR TITLE
refactor: 참석 여부 응답 API 수정

### DIFF
--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -21,7 +21,6 @@ interface GuestUseCase {
     ): Guest
 
     fun respondInvitation(
-        guestId: UUID?,
         invitationId: UUID,
         memberId: UUID,
         nickname: String,

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -24,4 +24,6 @@ interface GuestPersistencePort {
     fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
 
     fun findOwnerNickname(invitationId: UUID, memberId: UUID): String
+
+    fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID): UUID?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -58,6 +58,8 @@ class GuestService(
 
         val invitation = invitationUseCase.findById(invitationId)
 
+        val guestId = guestPersistencePort.findIdByMemberAndInvitation(memberId, invitationId)
+
         if (guestId == null) {
             guestPersistencePort.save(
                 GuestVO(

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -48,7 +48,6 @@ class GuestService(
     }
 
     override fun respondInvitation(
-        guestId: UUID?,
         invitationId: UUID,
         memberId: UUID,
         nickname: String,

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/entity/GuestEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/entity/GuestEntity.kt
@@ -31,7 +31,7 @@ class GuestEntity(
     @Column
     val nickname: String,
 
-    @Column(nullable = false)
+    @Column
     val attendance: Boolean,
 ) : BaseTimeEntity() {
     fun toDomain(): Guest =

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/entity/GuestEntity.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/entity/GuestEntity.kt
@@ -31,7 +31,7 @@ class GuestEntity(
     @Column
     val nickname: String,
 
-    @Column
+    @Column(nullable = false)
     val attendance: Boolean,
 ) : BaseTimeEntity() {
     fun toDomain(): Guest =

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -52,4 +52,10 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
         "WHERE g.member.id = :memberId " +
         "AND g.invitation.id = :invitationId")
     fun findOwnerNickname(invitationId: UUID, memberId: UUID): String
+
+    @Query("SELECT g.id " +
+            "FROM guest g " +
+            "WHERE g.member.id = :memberId " +
+            "AND g.invitation.id = :invitationId")
+    fun findIdByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): UUID?
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -16,10 +16,9 @@ import kotlin.jvm.optionals.getOrNull
 class GuestRepository(
     private val guestJPARepository: GuestJPARepository,
 ) : GuestPersistencePort {
-    override fun save(guestVo: GuestVO): Guest {
-        return guestJPARepository.save(GuestEntity.from(guestVo))
+    override fun save(guestVo: GuestVO) =
+        guestJPARepository.save(GuestEntity.from(guestVo))
             .toDomain()
-    }
 
     override fun save(guest: Guest) {
         guestJPARepository.save(GuestEntity.from(guest))
@@ -46,10 +45,12 @@ class GuestRepository(
             .map(GuestEntity::toDomain)
     }
 
-    override fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean? {
-        return guestJPARepository.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
-    }
+    override fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
+        guestJPARepository.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
 
     override fun findOwnerNickname(invitationId: UUID, memberId: UUID): String =
         guestJPARepository.findOwnerNickname(invitationId, memberId)
+
+    override fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
+        guestJPARepository.findIdByMemberIdAndInvitationId(memberId, invitationId)
 }

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/guest/repository/GuestRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/guest/repository/GuestRepositoryTest.kt
@@ -28,7 +28,7 @@ class GuestRepositoryTest(
     lateinit var invitationEntity: InvitationEntity
     lateinit var memberEntity: MemberEntity
 
-    beforeSpec {
+    beforeEach {
         memberEntity = MemberEntity.from(
             MemberVO(
                 socialId = "6316",
@@ -54,7 +54,7 @@ class GuestRepositoryTest(
         )
     }
 
-    afterSpec {
+    afterEach {
         guestJPARepository.deleteAllInBatch()
         invitationJPARepository.deleteAllInBatch()
         memberJPARepository.deleteAllInBatch()
@@ -70,6 +70,28 @@ class GuestRepositoryTest(
 
                 savedGuest.member.socialId shouldBe memberEntity.toDomain().socialId
                 savedGuest.invitation.id shouldBe invitationEntity.id
+            }
+        }
+
+        context("findIdByMemberIdAndInvitationId() 메서드에서") {
+            it("Guest가 존재하면 guestId를 반환해야 한다.") {
+                val savedGuest = guestRepository.save(guestVO)
+
+                val memberId = memberEntity.id!!
+                val invitationId = invitationEntity.id!!
+
+                val guestId = guestRepository.findIdByMemberAndInvitation(memberId, invitationId)
+
+                guestId shouldBe savedGuest.id
+            }
+
+            it("Guest가 존재하지 않으면 null을 반환해야 한다.") {
+                val memberId = memberEntity.id!!
+                val invitationId = invitationEntity.id!!
+
+                val guestId = guestRepository.findIdByMemberAndInvitation(memberId, invitationId)
+
+                guestId shouldBe null
             }
         }
     }

--- a/module-presentation/src/main/kotlin/site/yourevents/guest/dto/request/InvitationRespondRequest.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/guest/dto/request/InvitationRespondRequest.kt
@@ -3,7 +3,6 @@ package site.yourevents.guest.dto.request
 import java.util.UUID
 
 data class InvitationRespondRequest(
-    val guestId: UUID?,
     val invitationId: UUID,
     val nickname: String,
     val attendance: Boolean,

--- a/module-presentation/src/main/kotlin/site/yourevents/guest/facade/GuestFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/guest/facade/GuestFacade.kt
@@ -16,7 +16,6 @@ class GuestFacade(
         val memberId = authDetails.uuid
 
         guestUseCase.respondInvitation(
-            invitationRespondRequest.guestId,
             invitationRespondRequest.invitationId,
             memberId,
             invitationRespondRequest.nickname,

--- a/module-presentation/src/test/kotlin/site/yourevents/guest/facade/GuestFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/guest/facade/GuestFacadeTest.kt
@@ -25,12 +25,10 @@ class GuestFacadeTest : DescribeSpec({
                         any(),
                         any(),
                         any(),
-                        any()
                     )
                 } just runs
 
                 val request = InvitationRespondRequest(
-                    guestId = UUID.randomUUID(),
                     invitationId = UUID.randomUUID(),
                     nickname = "nickname",
                     attendance = true
@@ -49,7 +47,6 @@ class GuestFacadeTest : DescribeSpec({
                         any(),
                         any(),
                         any(),
-                        any()
                     )
                 }
                 confirmVerified(guestUseCase)


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용
- Repository
<img width="775" alt="스크린샷 2025-02-04 오전 12 37 17" src="https://github.com/user-attachments/assets/560718a8-cce4-4f6b-a31a-fed4305e2f14" />

- Service
<img width="761" alt="image" src="https://github.com/user-attachments/assets/13cbe692-d055-4b68-beb0-f0e105973864" />

- guestId를 `invitationId`와 `memberId`를 통해 조회하도록 변경하였습니다.
- 이에 DTO에서 `guestId` 필드를 삭제, 그에 맞추어 파사드 및 서비스 클래스 또한 변경하였습니다.
---

## 🔗 관련 이슈
- closes #41 

---

## 💡 추가 사항
- 중복 테스트 코드를 제거하였습니다.
- 기타 자잘한 컨벤션을 수정하였습니다.
- Guest 엔티티의 `attendance` 필드를 nullable로 수정하였습니다.
