### PR TITLE
refactor: 초대장 참석 여부 API 응답에 nickname 필드 추가

### DIFF
--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -33,5 +33,5 @@ interface GuestUseCase {
 
     fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean?
 
-    fun getOwnerNickname(invitationId: UUID, memberId: UUID): String
+    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -33,5 +33,5 @@ interface GuestUseCase {
 
     fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean?
 
-    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String
+    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/in/GuestUseCase.kt
@@ -33,5 +33,5 @@ interface GuestUseCase {
 
     fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean?
 
-    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String?
+    fun getNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -23,7 +23,7 @@ interface GuestPersistencePort {
 
     fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
 
-    fun findOwnerNickname(invitationId: UUID, memberId: UUID): String
+    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String
 
     fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID): UUID?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -23,7 +23,7 @@ interface GuestPersistencePort {
 
     fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
 
-    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String
+    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String?
 
     fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID): UUID?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/port/out/GuestPersistencePort.kt
@@ -21,9 +21,9 @@ interface GuestPersistencePort {
 
     fun findNotAttendGuestsByInvitation(invitation: Invitation): List<Guest>
 
-    fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID): Boolean?
+    fun findAttendanceByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): Boolean?
 
     fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String?
 
-    fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID): UUID?
+    fun findIdByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): UUID?
 }

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -58,7 +58,7 @@ class GuestService(
 
         val invitation = invitationUseCase.findById(invitationId)
 
-        val guestId = guestPersistencePort.findIdByMemberAndInvitation(memberId, invitationId)
+        val guestId = guestPersistencePort.findIdByMemberIdAndInvitationId(memberId, invitationId)
 
         if (guestId == null) {
             guestPersistencePort.save(
@@ -83,9 +83,9 @@ class GuestService(
     }
 
     override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? =
-        guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId)
+        guestPersistencePort.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
 
-    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID) =
+    override fun getNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID) =
         guestPersistencePort.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
 

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -85,8 +85,8 @@ class GuestService(
     override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? =
         guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId)
 
-    override fun getOwnerNickname(invitationId: UUID, memberId: UUID): String =
-        guestPersistencePort.findOwnerNickname(invitationId, memberId)
+    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String =
+        guestPersistencePort.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {
         val guest = guestPersistencePort.findById(guestId)

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -85,8 +85,10 @@ class GuestService(
     override fun getInvitationAttendance(memberId: UUID, invitationId: UUID): Boolean? =
         guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId)
 
-    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String =
+    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID) =
         guestPersistencePort.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
+            ?: throw GuestNotFoundException()
+
 
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {
         val guest = guestPersistencePort.findById(guestId)

--- a/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/guest/service/GuestService.kt
@@ -87,7 +87,6 @@ class GuestService(
 
     override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID) =
         guestPersistencePort.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
-            ?: throw GuestNotFoundException()
 
 
     private fun updateAttendance(guestId: UUID, attendance: Boolean) {

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -132,7 +132,7 @@ class GuestServiceTest : DescribeSpec({
                     modifiedAt = LocalDateTime.now()
                 )
 
-                every { guestPersistencePort.findIdByMemberAndInvitation(memberId, invitationId) } returns null
+                every { guestPersistencePort.findIdByMemberIdAndInvitationId(memberId, invitationId) } returns null
 
                 guestService.respondInvitation(
                     invitationId = invitationId,
@@ -144,7 +144,7 @@ class GuestServiceTest : DescribeSpec({
                 verify(exactly = 1) { memberUseCase.findById(memberId) }
                 verify(exactly = 1) { invitationUseCase.findById(invitationId) }
                 verify(exactly = 1) {
-                    guestPersistencePort.findIdByMemberAndInvitation(memberId, invitationId)
+                    guestPersistencePort.findIdByMemberIdAndInvitationId(memberId, invitationId)
                 }
                 verify(exactly = 1) {
                     guestPersistencePort.save(match<GuestVO> { guestVO ->
@@ -170,7 +170,7 @@ class GuestServiceTest : DescribeSpec({
                 )
 
                 every { guestPersistencePort.findById(any()) } returns expectedGuest
-                every { guestPersistencePort.findIdByMemberAndInvitation(memberId, invitationId) } returns guestId
+                every { guestPersistencePort.findIdByMemberIdAndInvitationId(memberId, invitationId) } returns guestId
 
                 val updatedAttendance = false
                 expectedGuest.updateAttendance(updatedAttendance)
@@ -192,7 +192,7 @@ class GuestServiceTest : DescribeSpec({
                 verify(exactly = 1) { guestPersistencePort.findById(any()) }
                 verify(exactly = 1) { guestPersistencePort.save(any<Guest>()) }
                 verify(exactly = 1) {
-                    guestPersistencePort.findIdByMemberAndInvitation(memberId, invitationId)
+                    guestPersistencePort.findIdByMemberIdAndInvitationId(memberId, invitationId)
                 }
                 confirmVerified(memberUseCase, invitationUseCase, guestPersistencePort)
             }
@@ -253,7 +253,7 @@ class GuestServiceTest : DescribeSpec({
                 val isAttending = true
 
                 every {
-                    guestPersistencePort.findAttendanceByMemberAndInvitation(
+                    guestPersistencePort.findAttendanceByMemberIdAndInvitationId(
                         memberId,
                         invitationId
                     )
@@ -263,7 +263,12 @@ class GuestServiceTest : DescribeSpec({
 
                 result shouldBe isAttending
 
-                verify(exactly = 1) { guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId) }
+                verify(exactly = 1) {
+                    guestPersistencePort.findAttendanceByMemberIdAndInvitationId(
+                        memberId,
+                        invitationId
+                    )
+                }
                 confirmVerified(guestPersistencePort)
             }
 
@@ -271,7 +276,7 @@ class GuestServiceTest : DescribeSpec({
                 val isAttending = false
 
                 every {
-                    guestPersistencePort.findAttendanceByMemberAndInvitation(
+                    guestPersistencePort.findAttendanceByMemberIdAndInvitationId(
                         memberId,
                         invitationId
                     )
@@ -281,7 +286,12 @@ class GuestServiceTest : DescribeSpec({
 
                 result shouldBe isAttending
 
-                verify(exactly = 1) { guestPersistencePort.findAttendanceByMemberAndInvitation(memberId, invitationId) }
+                verify(exactly = 1) {
+                    guestPersistencePort.findAttendanceByMemberIdAndInvitationId(
+                        memberId,
+                        invitationId
+                    )
+                }
                 confirmVerified(guestPersistencePort)
             }
         }
@@ -297,7 +307,7 @@ class GuestServiceTest : DescribeSpec({
                     )
                 } returns expectedNickname
 
-                val result = guestService.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
+                val result = guestService.getNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
                 result shouldBe expectedNickname
 

--- a/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
+++ b/module-domain/src/test/kotlin/site/yourevents/guest/service/GuestServiceTest.kt
@@ -1,12 +1,10 @@
 package site.yourevents.guest.service
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.*
 import site.yourevents.guest.domain.Guest
 import site.yourevents.guest.domain.GuestVO
-import site.yourevents.guest.exception.GuestNotFoundException
 import site.yourevents.guest.port.out.GuestPersistencePort
 import site.yourevents.invitation.domain.Invitation
 import site.yourevents.invitation.port.`in`.InvitationUseCase
@@ -302,27 +300,6 @@ class GuestServiceTest : DescribeSpec({
                 val result = guestService.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
                 result shouldBe expectedNickname
-
-                verify(exactly = 1) {
-                    guestPersistencePort.findNicknameByInvitationIdAndMemberId(
-                        invitationId,
-                        memberId
-                    )
-                }
-                confirmVerified(guestPersistencePort)
-            }
-
-            it("DB에 충족하는 nickname이 없으면, 예외가 발생해야 한다.") {
-                every {
-                    guestPersistencePort.findNicknameByInvitationIdAndMemberId(
-                        invitationId,
-                        memberId
-                    )
-                } returns null
-
-                shouldThrow<GuestNotFoundException> {
-                    guestService.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
-                }
 
                 verify(exactly = 1) {
                     guestPersistencePort.findNicknameByInvitationIdAndMemberId(

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -59,7 +59,7 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
                 "WHERE g.member.id = :memberId " +
                 "AND g.invitation.id = :invitationId"
     )
-    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String
+    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String?
 
     @Query(
         "SELECT g.id " +

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestJPARepository.kt
@@ -19,43 +19,53 @@ interface GuestJPARepository : JpaRepository<GuestEntity, UUID> {
 
     @Query(
         "SELECT DISTINCT i " +
-            "FROM guest g " +
-            "JOIN g.invitation i " +
-            "WHERE g.member = :memberEntity " +
-            "AND i.member <> :memberEntity " +
-            "AND i.deleted = false"
+                "FROM guest g " +
+                "JOIN g.invitation i " +
+                "WHERE g.member = :memberEntity " +
+                "AND i.member <> :memberEntity " +
+                "AND i.deleted = false"
     )
     fun getReceivedInvitations(memberEntity: MemberEntity): List<InvitationEntity>
 
-    @Query("SELECT g " +
-            "FROM guest g " +
-            "WHERE g.invitation = :invitationEntity " +
-            "AND g.attendance = true " +
-            "AND g.invitation.deleted = false")
+    @Query(
+        "SELECT g " +
+                "FROM guest g " +
+                "WHERE g.invitation = :invitationEntity " +
+                "AND g.attendance = true " +
+                "AND g.invitation.deleted = false"
+    )
     fun findAttendGuestsByInvitation(invitationEntity: InvitationEntity): List<GuestEntity>
 
-    @Query("SELECT g " +
+    @Query(
+        "SELECT g " +
                 "FROM guest g " +
                 "WHERE g.invitation = :invitationEntity " +
                 "AND g.attendance = false " +
-                "AND g.invitation.deleted = false")
+                "AND g.invitation.deleted = false"
+    )
     fun findNotAttendGuestsByInvitation(invitationEntity: InvitationEntity): List<GuestEntity>
 
-    @Query("SELECT g.attendance " +
-        "FROM guest g " +
-        "WHERE g.member.id = :memberId " +
-        "AND g.invitation.id = :invitationId")
+    @Query(
+        "SELECT g.attendance " +
+                "FROM guest g " +
+                "WHERE g.member.id = :memberId " +
+                "AND g.invitation.id = :invitationId"
+    )
     fun findAttendanceByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): Boolean?
 
-    @Query("SELECT g.nickname " +
-        "FROM guest g " +
-        "WHERE g.member.id = :memberId " +
-        "AND g.invitation.id = :invitationId")
-    fun findOwnerNickname(invitationId: UUID, memberId: UUID): String
+    @Query(
+        "SELECT g.nickname " +
+                "FROM guest g " +
+                "WHERE g.member.id = :memberId " +
+                "AND g.invitation.id = :invitationId"
+    )
+    fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String
 
-    @Query("SELECT g.id " +
-            "FROM guest g " +
-            "WHERE g.member.id = :memberId " +
-            "AND g.invitation.id = :invitationId")
+    @Query(
+        "SELECT g.id " +
+                "FROM guest g " +
+                "WHERE g.member.id = :memberId " +
+                "AND g.invitation.id = :invitationId"
+    )
     fun findIdByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID): UUID?
 }

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -48,8 +48,8 @@ class GuestRepository(
     override fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
         guestJPARepository.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
 
-    override fun findOwnerNickname(invitationId: UUID, memberId: UUID): String =
-        guestJPARepository.findOwnerNickname(invitationId, memberId)
+    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String =
+        guestJPARepository.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
     override fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
         guestJPARepository.findIdByMemberIdAndInvitationId(memberId, invitationId)

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -48,7 +48,7 @@ class GuestRepository(
     override fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
         guestJPARepository.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
 
-    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID): String =
+    override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID) =
         guestJPARepository.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
     override fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID) =

--- a/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
+++ b/module-infrastructure/persistence-db/src/main/kotlin/site/yourevents/guest/repository/GuestRepository.kt
@@ -45,12 +45,12 @@ class GuestRepository(
             .map(GuestEntity::toDomain)
     }
 
-    override fun findAttendanceByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
+    override fun findAttendanceByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID) =
         guestJPARepository.findAttendanceByMemberIdAndInvitationId(memberId, invitationId)
 
     override fun findNicknameByInvitationIdAndMemberId(invitationId: UUID, memberId: UUID) =
         guestJPARepository.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
-    override fun findIdByMemberAndInvitation(memberId: UUID, invitationId: UUID) =
+    override fun findIdByMemberIdAndInvitationId(memberId: UUID, invitationId: UUID) =
         guestJPARepository.findIdByMemberIdAndInvitationId(memberId, invitationId)
 }

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/guest/repository/GuestRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/guest/repository/GuestRepositoryTest.kt
@@ -20,7 +20,7 @@ import site.yourevents.member.repository.MemberJPARepository
 class GuestRepositoryTest(
     @Autowired private val guestJPARepository: GuestJPARepository,
     @Autowired private val memberJPARepository: MemberJPARepository,
-    @Autowired private val invitationJPARepository: InvitationJPARepository
+    @Autowired private val invitationJPARepository: InvitationJPARepository,
 ) : DescribeSpec({
     val guestRepository = GuestRepository(guestJPARepository)
 
@@ -80,7 +80,7 @@ class GuestRepositoryTest(
                 val memberId = memberEntity.id!!
                 val invitationId = invitationEntity.id!!
 
-                val guestId = guestRepository.findIdByMemberAndInvitation(memberId, invitationId)
+                val guestId = guestRepository.findIdByMemberIdAndInvitationId(memberId, invitationId)
 
                 guestId shouldBe savedGuest.id
             }
@@ -89,7 +89,7 @@ class GuestRepositoryTest(
                 val memberId = memberEntity.id!!
                 val invitationId = invitationEntity.id!!
 
-                val guestId = guestRepository.findIdByMemberAndInvitation(memberId, invitationId)
+                val guestId = guestRepository.findIdByMemberIdAndInvitationId(memberId, invitationId)
 
                 guestId shouldBe null
             }

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
@@ -5,5 +5,6 @@ import java.util.UUID
 data class InvitationAttendanceResponse(
     val invitationId: UUID,
     val memberId: UUID,
-    val attendance: Boolean?
+    val nickname: String,
+    val attendance: Boolean?,
 )

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/dto/response/InvitationAttendanceResponse.kt
@@ -5,6 +5,6 @@ import java.util.UUID
 data class InvitationAttendanceResponse(
     val invitationId: UUID,
     val memberId: UUID,
-    val nickname: String,
+    val nickname: String?,
     val attendance: Boolean?,
 )

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -75,7 +75,7 @@ class InvitationFacade(
 
         return InvitationInfoResponse.of(
             invitation,
-            ownerNickname,
+            ownerNickname!!,
             invitationInformation,
             invitationThumbnail
         )

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -4,7 +4,10 @@ import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import site.yourevents.guest.port.`in`.GuestUseCase
 import site.yourevents.invitation.dto.request.CreateInvitationRequest
-import site.yourevents.invitation.dto.response.*
+import site.yourevents.invitation.dto.response.InvitationAttendanceResponse
+import site.yourevents.invitation.dto.response.InvitationGuestResponse
+import site.yourevents.invitation.dto.response.InvitationInfoResponse
+import site.yourevents.invitation.dto.response.InvitationQrResponse
 import site.yourevents.invitation.exception.UnauthorizedException
 import site.yourevents.invitation.port.`in`.InvitationUseCase
 import site.yourevents.invitationinformation.port.`in`.InvitationInformationUseCase
@@ -64,7 +67,7 @@ class InvitationFacade(
     fun getInvitation(invitationId: UUID): InvitationInfoResponse {
         val invitation = invitationUseCase.findById(invitationId)
 
-        val ownerNickname = guestUseCase.getOwnerNickname(invitationId, invitation.member.id)
+        val ownerNickname = guestUseCase.findNicknameByInvitationIdAndMemberId(invitationId, invitation.member.id)
 
         val invitationInformation = invitationInformationUseCase.findByInvitation(invitation)
 

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -67,7 +67,7 @@ class InvitationFacade(
     fun getInvitation(invitationId: UUID): InvitationInfoResponse {
         val invitation = invitationUseCase.findById(invitationId)
 
-        val ownerNickname = guestUseCase.findNicknameByInvitationIdAndMemberId(invitationId, invitation.member.id)
+        val ownerNickname = guestUseCase.getNicknameByInvitationIdAndMemberId(invitationId, invitation.member.id)
 
         val invitationInformation = invitationInformationUseCase.findByInvitation(invitation)
 
@@ -98,7 +98,7 @@ class InvitationFacade(
     fun getInvitationAttendance(invitationId: UUID, authDetails: AuthDetails): InvitationAttendanceResponse {
         val memberId = authDetails.uuid
         val invitationAttendance = guestUseCase.getInvitationAttendance(memberId, invitationId)
-        val nickname = guestUseCase.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
+        val nickname = guestUseCase.getNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
         return InvitationAttendanceResponse(
             invitationId = invitationId,

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -98,10 +98,12 @@ class InvitationFacade(
     fun getInvitationAttendance(invitationId: UUID, authDetails: AuthDetails): InvitationAttendanceResponse {
         val memberId = authDetails.uuid
         val invitationAttendance = guestUseCase.getInvitationAttendance(memberId, invitationId)
+        val nickname = guestUseCase.findNicknameByInvitationIdAndMemberId(invitationId, memberId)
 
         return InvitationAttendanceResponse(
             invitationId = invitationId,
             memberId = memberId,
+            nickname = nickname,
             attendance = invitationAttendance
         )
     }

--- a/module-presentation/src/main/kotlin/site/yourevents/memeber/facade/MemberFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/memeber/facade/MemberFacade.kt
@@ -68,7 +68,7 @@ class MemberFacade(
     private fun createInvitationInfoResponse(invitation: Invitation): InvitationInfoResponse {
         val invitationInfo = invitationInformationUseCase.findByInvitation(invitation)
 
-        val ownerNickname = guestUseCase.getOwnerNickname(invitation.id, invitation.member.id)
+        val ownerNickname = guestUseCase.findNicknameByInvitationIdAndMemberId(invitation.id, invitation.member.id)
 
         val invitationThumbnail = invitationThumbnailUseCase.findByInvitation(invitation)
 

--- a/module-presentation/src/main/kotlin/site/yourevents/memeber/facade/MemberFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/memeber/facade/MemberFacade.kt
@@ -68,7 +68,7 @@ class MemberFacade(
     private fun createInvitationInfoResponse(invitation: Invitation): InvitationInfoResponse {
         val invitationInfo = invitationInformationUseCase.findByInvitation(invitation)
 
-        val ownerNickname = guestUseCase.findNicknameByInvitationIdAndMemberId(invitation.id, invitation.member.id)
+        val ownerNickname = guestUseCase.getNicknameByInvitationIdAndMemberId(invitation.id, invitation.member.id)
 
         val invitationThumbnail = invitationThumbnailUseCase.findByInvitation(invitation)
 

--- a/module-presentation/src/main/kotlin/site/yourevents/memeber/facade/MemberFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/memeber/facade/MemberFacade.kt
@@ -74,7 +74,7 @@ class MemberFacade(
 
         return InvitationInfoResponse.of(
             invitation,
-            ownerNickname,
+            ownerNickname!!,
             invitationInfo,
             invitationThumbnail
         )

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -153,7 +153,7 @@ class InvitationFacadeTest : DescribeSpec({
             it("존재하는 초대장 정보를 반환해야 한다") {
                 every { invitationUseCase.findById(invitationId) } returns invitation
                 every {
-                    guestUseCase.findNicknameByInvitationIdAndMemberId(
+                    guestUseCase.getNicknameByInvitationIdAndMemberId(
                         invitationId,
                         invitation.member.id
                     )
@@ -228,7 +228,7 @@ class InvitationFacadeTest : DescribeSpec({
                 val isAttending = true
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
-                every { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) } returns ownerNickname
+                every { guestUseCase.getNicknameByInvitationIdAndMemberId(any(), any()) } returns ownerNickname
 
                 val response = invitationFacade.getInvitationAttendance(invitationId, authDetails)
 
@@ -237,7 +237,7 @@ class InvitationFacadeTest : DescribeSpec({
                 response.attendance shouldBe isAttending
 
                 verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
-                verify(exactly = 1) { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) }
+                verify(exactly = 1) { guestUseCase.getNicknameByInvitationIdAndMemberId(any(), any()) }
                 confirmVerified(invitationUseCase, guestUseCase)
             }
 
@@ -245,7 +245,7 @@ class InvitationFacadeTest : DescribeSpec({
                 val isAttending = false
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
-                every { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) } returns ownerNickname
+                every { guestUseCase.getNicknameByInvitationIdAndMemberId(any(), any()) } returns ownerNickname
 
                 val response = invitationFacade.getInvitationAttendance(invitationId, authDetails)
 
@@ -254,7 +254,7 @@ class InvitationFacadeTest : DescribeSpec({
                 response.attendance shouldBe isAttending
 
                 verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
-                verify(exactly = 1) { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) }
+                verify(exactly = 1) { guestUseCase.getNicknameByInvitationIdAndMemberId(any(), any()) }
                 confirmVerified(invitationUseCase, guestUseCase)
             }
         }

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -228,6 +228,7 @@ class InvitationFacadeTest : DescribeSpec({
                 val isAttending = true
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
+                every { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) } returns ownerNickname
 
                 val response = invitationFacade.getInvitationAttendance(invitationId, authDetails)
 
@@ -236,6 +237,7 @@ class InvitationFacadeTest : DescribeSpec({
                 response.attendance shouldBe isAttending
 
                 verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
+                verify(exactly = 1) { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) }
                 confirmVerified(invitationUseCase, guestUseCase)
             }
 
@@ -243,6 +245,7 @@ class InvitationFacadeTest : DescribeSpec({
                 val isAttending = false
 
                 every { guestUseCase.getInvitationAttendance(memberId, invitationId) } returns isAttending
+                every { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) } returns ownerNickname
 
                 val response = invitationFacade.getInvitationAttendance(invitationId, authDetails)
 
@@ -251,6 +254,7 @@ class InvitationFacadeTest : DescribeSpec({
                 response.attendance shouldBe isAttending
 
                 verify(exactly = 1) { guestUseCase.getInvitationAttendance(memberId, invitationId) }
+                verify(exactly = 1) { guestUseCase.findNicknameByInvitationIdAndMemberId(any(), any()) }
                 confirmVerified(invitationUseCase, guestUseCase)
             }
         }

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -152,7 +152,12 @@ class InvitationFacadeTest : DescribeSpec({
         context("getInvitation 메서드가 호출되었을 때") {
             it("존재하는 초대장 정보를 반환해야 한다") {
                 every { invitationUseCase.findById(invitationId) } returns invitation
-                every { guestUseCase.getOwnerNickname(invitationId, invitation.member.id) } returns ownerNickname
+                every {
+                    guestUseCase.findNicknameByInvitationIdAndMemberId(
+                        invitationId,
+                        invitation.member.id
+                    )
+                } returns ownerNickname
                 every { invitationInformationUseCase.findByInvitation(invitation) } returns invitationInformation
                 every { invitationThumbnailUseCase.findByInvitation(invitation) } returns invitationThumbnail
 
@@ -217,7 +222,7 @@ class InvitationFacadeTest : DescribeSpec({
                 confirmVerified(guestUseCase)
             }
         }
-        
+
         context("getInvitationAttendance 메서드가 호출되었을 때") {
             it("참석 여부가 true로 반환되어야 한다") {
                 val isAttending = true
@@ -249,7 +254,7 @@ class InvitationFacadeTest : DescribeSpec({
                 confirmVerified(invitationUseCase, guestUseCase)
             }
         }
-        
+
         context("verifySender 메서드가 호출되었을 때") {
             it("초대장 주인이 사용자이면 true를 반환해야한다.") {
                 every { invitationUseCase.getOwnerId(any()) } returns memberId

--- a/module-presentation/src/test/kotlin/site/yourevents/member/facade/MemberFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/member/facade/MemberFacadeTest.kt
@@ -115,7 +115,7 @@ class MemberFacadeTest : DescribeSpec({
                 every { memberUseCase.findById(authDetails.uuid) } returns member
                 every { invitationUseCase.findByMember(member) } returns listOf(invitation)
                 every {
-                    guestUseCase.findNicknameByInvitationIdAndMemberId(
+                    guestUseCase.getNicknameByInvitationIdAndMemberId(
                         invitation.id,
                         invitation.member.id
                     )
@@ -170,7 +170,7 @@ class MemberFacadeTest : DescribeSpec({
                 every { memberUseCase.findById(authDetails.uuid) } returns member
                 every { guestUseCase.getReceivedInvitations(member) } returns listOf(invitation)
                 every {
-                    guestUseCase.findNicknameByInvitationIdAndMemberId(
+                    guestUseCase.getNicknameByInvitationIdAndMemberId(
                         invitation.id,
                         invitation.member.id
                     )

--- a/module-presentation/src/test/kotlin/site/yourevents/member/facade/MemberFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/member/facade/MemberFacadeTest.kt
@@ -1,4 +1,4 @@
-package site.yourevents.memeber.facade
+package site.yourevents.member.facade
 
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -15,6 +15,7 @@ import site.yourevents.invitationthumnail.port.`in`.InvitationThumbnailUseCase
 import site.yourevents.member.domain.Member
 import site.yourevents.member.port.`in`.MemberUseCase
 import site.yourevents.memeber.dto.response.MemberInfoResponse
+import site.yourevents.memeber.facade.MemberFacade
 import site.yourevents.principal.AuthDetails
 import java.time.LocalDateTime
 import java.util.UUID

--- a/module-presentation/src/test/kotlin/site/yourevents/member/facade/MemberFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/member/facade/MemberFacadeTest.kt
@@ -113,7 +113,12 @@ class MemberFacadeTest : DescribeSpec({
 
                 every { memberUseCase.findById(authDetails.uuid) } returns member
                 every { invitationUseCase.findByMember(member) } returns listOf(invitation)
-                every { guestUseCase.getOwnerNickname(invitation.id, invitation.member.id) } returns ownerNickname
+                every {
+                    guestUseCase.findNicknameByInvitationIdAndMemberId(
+                        invitation.id,
+                        invitation.member.id
+                    )
+                } returns ownerNickname
                 every { invitationInformationUseCase.findByInvitation(invitation) } returns invitationInfo
                 every { invitationThumbnailUseCase.findByInvitation(invitation) } returns invitationThumbnail
 
@@ -163,7 +168,12 @@ class MemberFacadeTest : DescribeSpec({
 
                 every { memberUseCase.findById(authDetails.uuid) } returns member
                 every { guestUseCase.getReceivedInvitations(member) } returns listOf(invitation)
-                every { guestUseCase.getOwnerNickname(invitation.id, invitation.member.id) } returns ownerNickname
+                every {
+                    guestUseCase.findNicknameByInvitationIdAndMemberId(
+                        invitation.id,
+                        invitation.member.id
+                    )
+                } returns ownerNickname
                 every { invitationInformationUseCase.findByInvitation(invitation) } returns invitationInfo
                 every { invitationThumbnailUseCase.findByInvitation(invitation) } returns invitationThumbnail
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용

- [x] 기존에 사용하던 `getOwnerNickname`메서드명을 `findNicknameByInvitationIdAndMemberId`로 변경하여, 코드의 재사용성 증가
- [ ] ~~`Not Found` 예외 처리 로직 추가~~
- [x] 초대장 참석 여부 API 응답에 `nickname` 필드 추가
- [x] 로직 수정에 따른 테스트 코드 변경
#### AS-IS
<img width="1394" alt="image" src="https://github.com/user-attachments/assets/8d98a302-2825-46ac-aa36-bb4b430f8c51" />

#### TO-BE
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/e29a0a1a-f8d6-4916-81d8-8e7af2e8197a" />

<img width="1396" alt="image" src="https://github.com/user-attachments/assets/0e2a4a3c-a60f-4295-a14b-0c024f3a21af" />


#### 테스트 코드 결과
- MemberFacade
<img width="451" alt="image" src="https://github.com/user-attachments/assets/c17b89d6-e51d-4615-a9b0-6d33e04e2ea5" />

- InvitationFacade
<img width="436" alt="image" src="https://github.com/user-attachments/assets/c2fa0cff-7f75-4b9a-ba46-cc8ee5e3866d" />

- GuestService
<img width="439" alt="image" src="https://github.com/user-attachments/assets/eefd6d33-4648-4154-8373-fd811f74a597" />

---


## 🔗 관련 이슈
- closes #43

---

## 💡 추가 사항
- 오탈자 및 기타 자잘한 컨벤션을 수정하였습니다.