### PR TITLE
refactor: S3 버킷 파일 구조 변경

### DIFF
--- a/module-domain/src/main/kotlin/site/yourevents/invitation/port/in/InvitationUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/invitation/port/in/InvitationUseCase.kt
@@ -11,7 +11,7 @@ interface InvitationUseCase {
 
     fun createInvitation(memberId: UUID, qrUrl: String, templateKey: String?): Invitation
 
-    fun updateQrCode(invitationId: UUID): Invitation
+    fun updateQrCode(invitation: Invitation, invitationTitle: String): Invitation
 
     fun findById(id: UUID): Invitation
 

--- a/module-domain/src/main/kotlin/site/yourevents/invitation/service/InvitationService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/invitation/service/InvitationService.kt
@@ -36,12 +36,10 @@ class InvitationService(
         )
     }
 
-    override fun updateQrCode(invitationId: UUID): Invitation {
-        val invitation = findById(invitationId)
+    override fun updateQrCode(invitation: Invitation, invitationTitle: String): Invitation {
+        val qrCode = qrCodeUseCase.generateQrCode(invitation.id)
 
-        val qrCode = qrCodeUseCase.generateQrCode(invitationId)
-
-        val qrUrl = qrCodeUseCase.uploadQrCode(invitationId.toString(), qrCode)
+        val qrUrl = qrCodeUseCase.uploadQrCode(invitation.id, invitationTitle, qrCode)
 
         invitation.updateQrCode(qrUrl)
 

--- a/module-domain/src/main/kotlin/site/yourevents/qr/port/in/QrCodeUseCase.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/qr/port/in/QrCodeUseCase.kt
@@ -5,5 +5,5 @@ import java.util.UUID
 interface QrCodeUseCase {
     fun generateQrCode(invitationId: UUID): ByteArray
 
-    fun uploadQrCode(imageName: String, qrCodeBytes: ByteArray): String
+    fun uploadQrCode(invitationId: UUID, invitationTitle: String, qrCodeBytes: ByteArray): String
 }

--- a/module-domain/src/main/kotlin/site/yourevents/qr/service/QrCodeService.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/qr/service/QrCodeService.kt
@@ -14,6 +14,6 @@ class QrCodeService(
     override fun generateQrCode(invitationId: UUID): ByteArray =
         qrCodePort.generate(invitationId)
 
-    override fun uploadQrCode(imageName: String, qrCodeBytes: ByteArray): String =
-        preSignedPort.uploadQrCode(imageName, qrCodeBytes)
+    override fun uploadQrCode(invitationId: UUID, invitationTitle: String, qrCodeBytes: ByteArray): String =
+        preSignedPort.uploadQrCode(invitationId, invitationTitle, qrCodeBytes)
 }

--- a/module-domain/src/main/kotlin/site/yourevents/s3/port/out/PreSignedUrlPort.kt
+++ b/module-domain/src/main/kotlin/site/yourevents/s3/port/out/PreSignedUrlPort.kt
@@ -1,7 +1,9 @@
 package site.yourevents.s3.port.out
 
+import java.util.UUID
+
 interface PreSignedUrlPort {
-    fun uploadQrCode(imageName: String, qrCodeBytes: ByteArray): String
+    fun uploadQrCode(invitationId: UUID, invitationTitle: String, qrCodeBytes: ByteArray): String
 
     fun getPreSignedUrl(imageName: String): String
 }

--- a/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
+++ b/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
@@ -48,7 +48,7 @@ class SecurityConfig(
                 whiteList.forEach { authorize(it, permitAll) }
 
                 // login
-                authorize(HttpMethod.POST, "/login", permitAll) // POST 허용
+                authorize(HttpMethod.POST, "/login", permitAll)
                 authorize("/login", denyAll)
 
                 // presigned url

--- a/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
+++ b/module-infrastructure/security/src/main/kotlin/site/yourevents/SecurityConfig.kt
@@ -39,7 +39,6 @@ class SecurityConfig(
         "/v3/**",
         "/health-check",
         "$actuatorEndPoint/**",
-        "/login"
     )
 
     @Bean
@@ -47,6 +46,10 @@ class SecurityConfig(
         http {
             authorizeHttpRequests {
                 whiteList.forEach { authorize(it, permitAll) }
+
+                // login
+                authorize(HttpMethod.POST, "/login", permitAll) // POST 허용
+                authorize("/login", denyAll)
 
                 // presigned url
                 authorize("/presignedurl", authenticated)

--- a/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
+++ b/module-presentation/src/main/kotlin/site/yourevents/invitation/facade/InvitationFacade.kt
@@ -32,15 +32,13 @@ class InvitationFacade(
     ): UUID {
         val memberId = authDetails.uuid
 
-        val invitation = invitationUseCase.updateQrCode(
-            generateInvitation(memberId, createInvitationRequest.templateKey).id
-        )
+        val invitation = generateInvitation(memberId, createInvitationRequest.templateKey)
 
         generateOwner(memberId, invitation.id, createInvitationRequest.ownerNickname)
 
         generateInvitationThumbnail(invitation.id, createInvitationRequest.thumbnailUrl)
 
-        generateInvitationInformation(
+        val invitationInfo = generateInvitationInformation(
             invitation.id,
             title = createInvitationRequest.title,
             schedule = createInvitationRequest.schedule,
@@ -48,7 +46,7 @@ class InvitationFacade(
             remark = createInvitationRequest.remark
         )
 
-        return invitation.id
+        return invitationUseCase.updateQrCode(invitation, invitationInfo.title).id
     }
 
     fun deleteInvitation(

--- a/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
+++ b/module-presentation/src/test/kotlin/site/yourevents/invitation/facade/InvitationFacadeTest.kt
@@ -72,7 +72,7 @@ class InvitationFacadeTest : DescribeSpec({
             modifiedAt = LocalDateTime.now()
         )
 
-        every { invitationUseCase.updateQrCode(any()) } returns invitation
+        every { invitationUseCase.updateQrCode(any(), any()) } returns invitation
 
         val guest = Guest(
             id = ownerId,
@@ -114,7 +114,7 @@ class InvitationFacadeTest : DescribeSpec({
                 every {
                     invitationUseCase.createInvitation(any(), any(), any())
                 } answers {
-                    invitationUseCase.updateQrCode(invitation.id)
+                    invitationUseCase.updateQrCode(invitation, invitationInformation.title)
                     invitation
                 }
                 every { guestUseCase.createGuest(any(), any(), any()) } returns guest


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용
### S3 버킷 구조를 다음과 같이 폴더 구조를 변경합니다.
> [!NOTE]
Amazon S3 버킷은 `/`을 통해 폴더의 계층 구조를 구별하기 때문에, 코드에서 `/`을 사용해서, 구조를 변경하였습니다.
#### AS-IS
```
📦s3_bucket
┣ 🖼️invitation_thumbnail (random uuid+ title)
┗ 🖼️invitation_QRCode (invitation id)
```
#### TO-BE
```
📦s3_bucket
┣ 📂thumbnail
┃ ┗ 🖼️invitation_thumbnail (random uuid+ title)
┣ 📂QRCode
┃ ┗ 📂(invitation_id)
┃ ┃ ┗🖼️invitation_QRCode (invitation name)
```

#### 초대장 썸네일 파일 구조 변경
![image](https://github.com/user-attachments/assets/569208c9-8215-432f-954d-1dbc0dfea77e)
![image](https://github.com/user-attachments/assets/79ff7b95-a7f5-4660-acbc-730fdc3d29a9)

#### 초대장 QR 코드 파일 구조 변경
![image](https://github.com/user-attachments/assets/e3219cb6-b81b-4e6d-abec-fd11dea03431)
![image](https://github.com/user-attachments/assets/c2f566d1-b0a5-4cb8-9c51-c56cdb31f241)

- 로직 변경으로 인해 수정이 필요한 테스트 코드로 수정 완료했습니다.
![image](https://github.com/user-attachments/assets/f1ceefb3-ed47-4519-b3f4-03c95608d06b)

- 아래의 로그와 같이, 크롤링 봇이 의도치 않은 요청을 보내, 의도치 않은 오류가 발생하고 있었습니다.
이를 해결 위해, `/login`엔드포인트에서 `POST`을 제외한 모든 http method를 차단합니다.
```
196.251.85.250 - - [02/Mar/2025:12:06:05 +0000] "GET /login.rsp HTTP/1.1" 301 169 "-" "Hello World" "-"
196.251.85.250 - - [02/Mar/2025:12:06:05 +0000] "GET /login.rsp HTTP/1.1" 301 169 "-" "Hello World"
```
![image](https://github.com/user-attachments/assets/960da91d-c01d-45fb-8826-71a7b32b7491)


---

## 🔗 관련 이슈
- closes #45

---

## 💡 추가 사항
- 초대장 썸네일은 presignedUrl을 통해, S3 버킷에 저장되기 때문에, `invitationId`가 생성되기 전에 해당 url이 발급이 됩니다. 따라서 부득이하게 `invitation`별로 관리를 하지 못하게 되었습니다.
- QR 코드 같은 경우에는 사용자가 직접 다운로드를 하는 파일이기 때문에, 파일 관리의 용이성을 위해 `invitation`이름으로 파일을 저장할 수 있도록 위와 같은 구조로 관리합니다.
