### PR TITLE
bug: S3 버킷 한글 파일명 처리 오류 수정

### DIFF
--- a/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
+++ b/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
@@ -27,8 +27,7 @@ class S3Service(
         val metadata = ObjectMetadata().apply {
             contentType = "image/png"
             contentLength = qrCodeBytes.size.toLong()
-            contentDisposition =
-                "attachment; filename=\"${URLEncoder.encode(invitationTitle, StandardCharsets.UTF_8)}.png\""
+            contentDisposition = "attachment; filename=\"${encodeFileName(invitationTitle)}.png\""
         }
 
         amazonS3.putObject(bucketName, path, inputStream, metadata)
@@ -47,4 +46,8 @@ class S3Service(
         GeneratePresignedUrlRequest(bucket, fileName)
             .withMethod(HttpMethod.PUT)
             .withExpiration(Date(System.currentTimeMillis() + (1000 * 60 * 2)))
+
+    private fun encodeFileName(fileName: String): String =
+        URLEncoder.encode(fileName, StandardCharsets.UTF_8)
+            .replace("+", "%20")
 }

--- a/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
+++ b/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
@@ -36,7 +36,7 @@ class S3Service(
     }
 
     override fun getPreSignedUrl(imageName: String): String {
-        val fileName = String.format("thumbnail/%S", UUID.randomUUID().toString() + imageName)
+        val fileName = "thumbnail/${UUID.randomUUID()}-$imageName"
         val getGeneratePresignedUrlRequest = getGeneratePreSignedUrlRequest(bucketName, fileName)
         val preSignedUrl: URL = amazonS3.generatePresignedUrl(getGeneratePresignedUrlRequest)
 
@@ -46,14 +46,7 @@ class S3Service(
     private fun getGeneratePreSignedUrlRequest(bucket: String, fileName: String): GeneratePresignedUrlRequest =
         GeneratePresignedUrlRequest(bucket, fileName)
             .withMethod(HttpMethod.PUT)
-            .withExpiration(getPreSignedUrlExpiration())
-
-    private fun getPreSignedUrlExpiration(): Date {
-        val expiration = Date()
-        val expTimeMillis = expiration.time + (1000 * 60 * 2)
-        expiration.time = expTimeMillis
-        return expiration
-    }
+            .withExpiration(Date(System.currentTimeMillis() + (1000 * 60 * 2)))
 
     private fun encodeFileName(fileName: String): String =
         URLEncoder.encode(fileName, StandardCharsets.UTF_8.toString())

--- a/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
+++ b/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
@@ -22,13 +22,12 @@ class S3Service(
 ) : PreSignedUrlPort {
 
     override fun uploadQrCode(invitationId: UUID, invitationTitle: String, qrCodeBytes: ByteArray): String {
-        val safeTitle = encodeFileName(invitationTitle)
-        val path = "qr/$invitationId/$safeTitle.png"
+        val path = "qr/$invitationId/$invitationTitle.png"
         val inputStream = qrCodeBytes.inputStream()
         val metadata = ObjectMetadata().apply {
             contentType = "image/png"
             contentLength = qrCodeBytes.size.toLong()
-            contentDisposition = "attachment; filename=\"$safeTitle.png\""
+            contentDisposition = "attachment; filename=\"${encodeFileName(invitationTitle)}.png\""
         }
 
         amazonS3.putObject(bucketName, path, inputStream, metadata)

--- a/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
+++ b/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
@@ -27,7 +27,8 @@ class S3Service(
         val metadata = ObjectMetadata().apply {
             contentType = "image/png"
             contentLength = qrCodeBytes.size.toLong()
-            contentDisposition = "attachment; filename=\"${encodeFileName(invitationTitle)}.png\""
+            contentDisposition =
+                "attachment; filename=\"${URLEncoder.encode(invitationTitle, StandardCharsets.UTF_8)}.png\""
         }
 
         amazonS3.putObject(bucketName, path, inputStream, metadata)
@@ -46,8 +47,4 @@ class S3Service(
         GeneratePresignedUrlRequest(bucket, fileName)
             .withMethod(HttpMethod.PUT)
             .withExpiration(Date(System.currentTimeMillis() + (1000 * 60 * 2)))
-
-    private fun encodeFileName(fileName: String): String =
-        URLEncoder.encode(fileName, StandardCharsets.UTF_8.toString())
-            .replace("+", "%20")
 }

--- a/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
+++ b/module-infrastructure/s3/src/main/kotlin/site/yourevents/service/S3Service.kt
@@ -7,9 +7,8 @@ import com.amazonaws.services.s3.model.ObjectMetadata
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import site.yourevents.s3.port.out.PreSignedUrlPort
+import java.net.URI
 import java.net.URL
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import java.util.Date
 import java.util.UUID
 
@@ -27,7 +26,8 @@ class S3Service(
         val metadata = ObjectMetadata().apply {
             contentType = "image/png"
             contentLength = qrCodeBytes.size.toLong()
-            contentDisposition = "attachment; filename=\"${encodeFileName(invitationTitle)}.png\""
+            contentDisposition =
+                "attachment; filename=\"${URI(null, null, invitationTitle, null).toASCIIString()}.png\""
         }
 
         amazonS3.putObject(bucketName, path, inputStream, metadata)
@@ -46,8 +46,4 @@ class S3Service(
         GeneratePresignedUrlRequest(bucket, fileName)
             .withMethod(HttpMethod.PUT)
             .withExpiration(Date(System.currentTimeMillis() + (1000 * 60 * 2)))
-
-    private fun encodeFileName(fileName: String): String =
-        URLEncoder.encode(fileName, StandardCharsets.UTF_8)
-            .replace("+", "%20")
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### S3 버킷에 한글 파일명으로 업로드 시 발생하는 오류를 해결하였습니다.
> [!NOTE] 
해당 오류가 발생한 원인이 무엇인가요?

`metadata`의 `contentDisposition`은 브라우저가 파일 다운로드 시 처리하는 HTTP 헤더입니다. 해당 데이터는 영어 이외의 문자를 포함하면 반드시 인코딩을 적용해야 하는데, S3 버킷에 한글 파일을 업로드할 때 인코딩이 되는 로직이 빠져있어 발생한 오류입니다.

#### SWAGGER Test
<img width="1395" alt="image" src="https://github.com/user-attachments/assets/fbbe8b2e-029f-4d0f-bd0c-06364956fdac" />

#### S3 버킷 업로드 정보
<img width="1734" alt="image" src="https://github.com/user-attachments/assets/5a946cbd-af1f-498a-8d6a-bb7ff26ea556" />

#### S3 버킷에서 다운로드하는 이미지
<img width="346" alt="image" src="https://github.com/user-attachments/assets/a4dd5787-a745-45dd-b80f-e37bde3d4852" />

### `PreSignedUrl` 생성 코드를 간결화하고 가독성을 향상시켰습니다.
#### S3 버킷 업로드 정보
<img width="834" alt="image" src="https://github.com/user-attachments/assets/c5061aec-708b-400b-89c1-da637682ef2a" />

---

## 🔗 관련 이슈
- closes #47

---

## 💡 추가 사항
- `PreSignedUrl`을 통해 업로드되는 파일은 `UUID`와 파일 이름을`-`을 통해서 구별하도록 변경하였습니다!