### PR TITLE
test: InvitationInformation, Thumbnail관련 Repository 테스트 코드 구현

### DIFF
--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
@@ -1,6 +1,7 @@
 package site.yourevents.invitationinformation.repository
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.jdbc.EmbeddedDatabaseConnection
@@ -21,7 +22,7 @@ import java.time.LocalDateTime
 class InvitationInformationRepositoryTest(
     @Autowired private val invitationInformationJPARepository: InvitationInformationJPARepository,
     @Autowired private val invitationJPARepository: InvitationJPARepository,
-    @Autowired private val memberJPARepository: MemberJPARepository
+    @Autowired private val memberJPARepository: MemberJPARepository,
 ) : DescribeSpec({
 
     val invitationInformationRepository = InvitationInformationRepository(invitationInformationJPARepository)
@@ -64,20 +65,49 @@ class InvitationInformationRepositoryTest(
     }
 
     describe("InvitationInformationRepository") {
-        it("save() 메서드를 통해 InvitationInformation을 저장하고 반환해야 한다") {
-            val savedInfo = invitationInformationRepository.save(invitationInformationVO)
+        context("findByInvitation() 메서드에서") {
+            it("저장된 InvitationInformation을 조회해야 한다") {
+                val savedInfo = invitationInformationRepository.save(invitationInformationVO)
+                val foundInfo = invitationInformationRepository.findByInvitation(savedInfo.invitation)
 
-            savedInfo.title shouldBe invitationInformationVO.title
-            savedInfo.schedule shouldBe invitationInformationVO.schedule
-            savedInfo.location shouldBe invitationInformationVO.location
-            savedInfo.remark shouldBe invitationInformationVO.remark
-            savedInfo.invitation.id shouldBe invitationEntity.id
-            savedInfo.invitation.qrUrl shouldBe invitationEntity.qrUrl
-            savedInfo.invitation.templateKey shouldBe invitationEntity.templateKey
-            savedInfo.invitation.deleted shouldBe invitationEntity.deleted
-            savedInfo.invitation.member.socialId shouldBe memberEntity.toDomain().socialId
-            savedInfo.invitation.member.nickname shouldBe memberEntity.toDomain().nickname
-            savedInfo.invitation.member.email shouldBe memberEntity.toDomain().email
+                foundInfo.shouldNotBeNull()
+
+                foundInfo.title shouldBe invitationInformationVO.title
+                foundInfo.location shouldBe invitationInformationVO.location
+                foundInfo.remark shouldBe invitationInformationVO.remark
+                foundInfo.invitation.id shouldBe invitationEntity.id
+            }
+
+            it("InvitationInformation이 없는 경우 null을 반환해야 한다") {
+                val newInvitationEntity = InvitationEntity(
+                    member = memberEntity,
+                    qrUrl = "http://example.org",
+                    templateKey = "newTemplate",
+                    deleted = false
+                )
+                invitationJPARepository.save(newInvitationEntity)
+
+                val foundInfo = invitationInformationRepository.findByInvitation(newInvitationEntity.toDomain())
+                foundInfo shouldBe null
+            }
+        }
+
+        context("save() 메서드에서") {
+            it("InvitationInformation을 저장하고 반환해야 한다") {
+                val savedInfo = invitationInformationRepository.save(invitationInformationVO)
+
+                savedInfo.title shouldBe invitationInformationVO.title
+                savedInfo.schedule shouldBe invitationInformationVO.schedule
+                savedInfo.location shouldBe invitationInformationVO.location
+                savedInfo.remark shouldBe invitationInformationVO.remark
+                savedInfo.invitation.id shouldBe invitationEntity.id
+                savedInfo.invitation.qrUrl shouldBe invitationEntity.qrUrl
+                savedInfo.invitation.templateKey shouldBe invitationEntity.templateKey
+                savedInfo.invitation.deleted shouldBe invitationEntity.deleted
+                savedInfo.invitation.member.socialId shouldBe memberEntity.toDomain().socialId
+                savedInfo.invitation.member.nickname shouldBe memberEntity.toDomain().nickname
+                savedInfo.invitation.member.email shouldBe memberEntity.toDomain().email
+            }
         }
     }
 })

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
@@ -74,7 +74,7 @@ class InvitationInformationRepositoryTest(
                 foundInfo.shouldNotBeNull()
 
                 foundInfo.title shouldBe invitationInformationVO.title
-                foundInfo.schedule.truncatedTo(ChronoUnit.MICROS) shouldBe invitationInformationVO.schedule.truncatedTo(ChronoUnit.MICROS)
+                foundInfo.schedule.truncatedTo(ChronoUnit.MILLIS) shouldBe invitationInformationVO.schedule.truncatedTo(ChronoUnit.MILLIS)
                 foundInfo.location shouldBe invitationInformationVO.location
                 foundInfo.remark shouldBe invitationInformationVO.remark
                 foundInfo.invitation.id shouldBe invitationEntity.id

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
@@ -15,6 +15,7 @@ import site.yourevents.member.domain.MemberVO
 import site.yourevents.member.entity.MemberEntity
 import site.yourevents.member.repository.MemberJPARepository
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @ActiveProfiles("test")
 @DataJpaTest
@@ -73,6 +74,7 @@ class InvitationInformationRepositoryTest(
                 foundInfo.shouldNotBeNull()
 
                 foundInfo.title shouldBe invitationInformationVO.title
+                foundInfo.schedule.truncatedTo(ChronoUnit.MICROS) shouldBe invitationInformationVO.schedule.truncatedTo(ChronoUnit.MICROS)
                 foundInfo.location shouldBe invitationInformationVO.location
                 foundInfo.remark shouldBe invitationInformationVO.remark
                 foundInfo.invitation.id shouldBe invitationEntity.id

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
@@ -15,7 +15,6 @@ import site.yourevents.member.domain.MemberVO
 import site.yourevents.member.entity.MemberEntity
 import site.yourevents.member.repository.MemberJPARepository
 import java.time.LocalDateTime
-import java.time.temporal.ChronoUnit
 
 @ActiveProfiles("test")
 @DataJpaTest

--- a/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
+++ b/module-infrastructure/persistence-db/src/test/kotlin/site/yourevents/invitationinformation/repository/InvitationInformationRepositoryTest.kt
@@ -53,7 +53,7 @@ class InvitationInformationRepositoryTest(
         invitationInformationVO = InvitationInformationVO(
             invitation = invitationEntity.toDomain(),
             title = "title",
-            schedule = LocalDateTime.now(),
+            schedule = LocalDateTime.of(2025, 3, 14, 12, 0, 0),
             location = "location",
             remark = "remark"
         )
@@ -74,7 +74,7 @@ class InvitationInformationRepositoryTest(
                 foundInfo.shouldNotBeNull()
 
                 foundInfo.title shouldBe invitationInformationVO.title
-                foundInfo.schedule.truncatedTo(ChronoUnit.MILLIS) shouldBe invitationInformationVO.schedule.truncatedTo(ChronoUnit.MILLIS)
+                foundInfo.schedule shouldBe invitationInformationVO.schedule
                 foundInfo.location shouldBe invitationInformationVO.location
                 foundInfo.remark shouldBe invitationInformationVO.remark
                 foundInfo.invitation.id shouldBe invitationEntity.id


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 테스트 코드 추가

---

## ✏️ 작업 내용
**1. invitationInformationRepository 테스트 코드를 작성하였습니다.**

- 코드 작성 중 다음과 같이 코드를 작성할 경우 오류가 발생하는 것을 알아냈습니다. 이는 두 값이 모두 LocalDateTime 타입이어도 내부 nanosecond 정밀도가 다르기 때문에 문제가 발생하는 것이었습니다.
- 따라서 다음과 같이 코드를 수정하여 정밀도를 동일하게 설정하였습니다.
```kotlin
//수정 전
foundInfo.schedule shouldBe invitationInformationVO.schedule

//수정 후
foundInfo.schedule.truncatedTo(ChronoUnit.MILLIS) shouldBe invitationInformationVO.schedule.truncatedTo(ChronoUnit.MILLIS)
``` 

**2. invitationThumbailRepository 테스트 코드를 작성하였습니다.**

---

## 🔗 관련 이슈
- closes #51 

---

## 💡 추가 사항

